### PR TITLE
Only add prediction to input line when there is some input

### DIFF
--- a/doc/_set.txt
+++ b/doc/_set.txt
@@ -150,6 +150,7 @@ This prevents the shell from exiting when you accidentally hit Ctrl-D.
 [[so-leconvmeta]]le-conv-meta::
 [[so-lenoconvmeta]]le-no-conv-meta::
 [[so-lepredict]]le-predict::
+[[so-lepredictempty]]le-predictemty::
 [[so-lepromptsp]]le-prompt-sp::
 [[so-levisiblebell]]le-visible-bell::
 See link:lineedit.html#options[shell options on line-editing].

--- a/doc/lineedit.txt
+++ b/doc/lineedit.txt
@@ -68,6 +68,10 @@ depending on terminfo data.
 link:_set.html#so-lepredict[le-predict]::
 activates <<prediction,command line prediction>>.
 
+link:_set.html#so-lepredictempty[le-predictempty]::
+When enabled, and <<prediction,command line prediction>> is active,
+suggestions are also provided for empty input lines.
+
 link:_set.html#so-lepromptsp[le-prompt-sp]::
 When enabled, the shell prints a special character sequence before printing
 each prompt so that every prompt is printed at the beginning of a line.

--- a/lineedit/editing.c
+++ b/lineedit/editing.c
@@ -2559,7 +2559,7 @@ void update_buffer_with_prediction(void)
 {
     clear_prediction();
 
-    if (le_main_index < active_length())
+    if (active_length() == 0 || le_main_index < active_length())
 	return;
     le_main_length = le_main_buffer.length;
 

--- a/lineedit/editing.c
+++ b/lineedit/editing.c
@@ -2559,8 +2559,12 @@ void update_buffer_with_prediction(void)
 {
     clear_prediction();
 
-    if (active_length() == 0 || le_main_index < active_length())
+    if (!shopt_le_predictempty && active_length() == 0)
 	return;
+
+    if (le_main_index < active_length())
+	return;
+
     le_main_length = le_main_buffer.length;
 
     wchar_t *suffix = trie_probable_key(

--- a/option.c
+++ b/option.c
@@ -190,6 +190,8 @@ bool shopt_le_alwaysrp = false;
 /* If set, auto-suggest the most probable command line as the user enters a
  * command line. */
 bool shopt_le_predict = false;
+/* If set, auto-suggest also provides suggestions for empty input lines. */
+bool shopt_le_predictempty = false;
 /* If set, debugging information is printed during command completion. */
 bool shopt_le_compdebug = false;
 #endif
@@ -234,6 +236,7 @@ static const struct option_T shell_options[] = {
     { 0,    0,    L"leconvmeta",     &shopt_le_yesconvmeta, true, },
     { 0,    0,    L"lenoconvmeta",   &shopt_le_noconvmeta,  true, },
     { 0,    0,    L"lepredict",      &shopt_le_predict,     true, },
+    { 0,    0,    L"lepredictempty", &shopt_le_predictempty,true, },
     { 0,    0,    L"lepromptsp",     &shopt_le_promptsp,    true, },
     { 0,    0,    L"levisiblebell",  &shopt_le_visiblebell, true, },
 #endif

--- a/option.h
+++ b/option.h
@@ -57,7 +57,7 @@ extern _Bool shopt_clobber;
 extern enum shopt_lineedit_T shopt_lineedit;
 extern enum shopt_yesnoauto_T shopt_le_convmeta;
 extern _Bool shopt_le_visiblebell, shopt_le_promptsp, shopt_le_alwaysrp,
-       shopt_le_predict, shopt_le_compdebug;
+       shopt_le_predict, shopt_le_predictempty, shopt_le_compdebug;
 #endif
 
 /* Whether or not this shell process is doing job control right now. */

--- a/share/completion/set
+++ b/share/completion/set
@@ -265,6 +265,7 @@ function completion/set::getopt {
 		"leconvmeta; always treat meta-key flags in line-editing"
 		"lenoconvmeta; never treat meta-key flags in line-editing"
 		"lepredict; suggest a command fragment while line-editing"
+		"lepredictempty; suggest a command fragment on empty input while line-editing"
 		"levisiblebell; alert with a flash, not a bell"
 		"lepromptsp; ensure the prompt is printed at the beginning of a line"
 		"lealwaysrp; always show the right prompt during line-editing"

--- a/tests/help-y.tst
+++ b/tests/help-y.tst
@@ -762,6 +762,7 @@ Options:
 	         -o leconvmeta
 	         -o lenoconvmeta
 	         -o lepredict
+	         -o lepredictempty
 	         -o lepromptsp
 	         -o levisiblebell
 	         -o log

--- a/tests/startup-y.tst
+++ b/tests/startup-y.tst
@@ -563,6 +563,7 @@ Options:
 	         -o leconvmeta
 	         -o lenoconvmeta
 	         -o lepredict
+	         -o lepredictempty
 	         -o lepromptsp
 	         -o levisiblebell
 	         -o log
@@ -619,6 +620,7 @@ Options:
 	         -o leconvmeta
 	         -o lenoconvmeta
 	         -o lepredict
+	         -o lepredictempty
 	         -o lepromptsp
 	         -o levisiblebell
 	         -o log


### PR DESCRIPTION
Personally I like the line input prediction feature very useful, but I find it confusing that there is a suggestion on empty input lines. This patch disables showing any prediction on empty input.

I have checked how other shells do this, and for example Zsh with [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) ([screencast](https://asciinema.org/a/37390)) and Fish ([screencast](https://asciinema.org/a/183906)) do not show suggestions when the input is empty.

----

P.S: @magicant, it looks like the main repository for Yash is the Subversion one, so please let me know if you prefer contributions to be sent in some other way instead of GitHub PRs. 

