### PR TITLE
Allow configuring predict style through the PS*P variable

### DIFF
--- a/input.c
+++ b/input.c
@@ -323,10 +323,12 @@ struct promptset_T get_prompt(int type)
 
 	result.right  = xwcsdup(L"");
 	result.styler = xwcsdup(L"");
+	result.predict = xwcsdup(L"");
     } else {
 	result.main = prompt;
 	result.right = expand_prompt_variable(num, L'R');
 	result.styler = expand_prompt_variable(num, L'S');
+	result.predict = expand_prompt_variable(num, L'P');
     }
 
     return result;

--- a/input.h
+++ b/input.h
@@ -24,7 +24,7 @@
 
 
 struct promptset_T {
-    wchar_t *main, *right, *styler;
+    wchar_t *main, *right, *styler, *predict;
 };
 
 #define PROMPT_RESET L"\\fD"
@@ -42,6 +42,7 @@ void free_prompt(struct promptset_T prompt)
     free(prompt.main);
     free(prompt.right);
     free(prompt.styler);
+    free(prompt.predict);
 }
 
 

--- a/lineedit/display.c
+++ b/lineedit/display.c
@@ -705,11 +705,15 @@ void update_editline(void)
 	    = lebuf.pos.line * lebuf.maxcolumn + lebuf.pos.column;
 	if (index == le_main_buffer.length)
 	    break;
-	if (styler_active && index >= le_main_length)
+	if (styler_active && index >= le_main_length) {
 	    lebuf_print_sgr0(), styler_active = false;
+	    lebuf_print_prompt(prompt.predict);
+	}
 	lebuf_putwchar(c, true);
 	index++;
     }
+    lebuf_print_sgr0(), styler_active = false;
+
     current_length = le_main_length;
 
     fillip_cursor();


### PR DESCRIPTION
This is an attempt to allow customizing the style of predictions.

This is probably implemented badly, and not POSIX.

Thanks for this great shell, I have been searching for this for a long
time, and that was the very last thing that bugged me.
