### PR TITLE
Implement emacs-search-{forward,backward}-current.

### DIFF
--- a/doc/lineedit.txt
+++ b/doc/lineedit.txt
@@ -1329,6 +1329,10 @@ ifdef::basebackend-html[+++<kbd><code>\^S</code></kbd>+++]
 ifndef::basebackend-html[`\^S`]
 --
 
+emacs-search-forward-current::
+The same as emacs-search-forward, but the search is initialised with the
+current contents of the line-edit buffer.
+
 emacs-search-backward::
 Switch to the emacs search mode and start backward
 link:interact.html#history[history] search.
@@ -1338,6 +1342,10 @@ emacs::
 ifdef::basebackend-html[+++<kbd><code>\^R</code></kbd>+++]
 ifndef::basebackend-html[`\^R`]
 --
+
+emacs-search-backward-current::
+The same as emacs-search-backward, but the search is initialised with the
+current contents of the line-edit buffer.
 
 [[history-commands]]
 === History-related commands

--- a/lineedit/editing.h
+++ b/lineedit/editing.h
@@ -194,7 +194,9 @@ extern le_command_func_T
     cmd_emacs_delete_horizontal_space, /*C*/
     cmd_emacs_just_one_space, /*C*/
     cmd_emacs_search_forward, /*C*/
-    cmd_emacs_search_backward; /*C*/
+    cmd_emacs_search_backward, /*C*/
+    cmd_emacs_search_forward_current, /*C*/
+    cmd_emacs_search_backward_current; /*C*/
 
 /* history-related commands */
 extern le_command_func_T

--- a/tests/bindkey-y.tst
+++ b/tests/bindkey-y.tst
@@ -139,6 +139,8 @@ emacs-delete-horizontal-space
 emacs-just-one-space
 emacs-search-forward
 emacs-search-backward
+emacs-search-forward-current
+emacs-search-backward-current
 oldest-history
 newest-history
 return-history


### PR DESCRIPTION
Here's a very quick attempt at the feature we discussed [over here](https://github.com/magicant/yash/discussions/36)

A variant of `emacs-search-backward` which initialises the search buffer with the contents of the line edit buffer.

This seems to work, but since I'm not very familiar with the codebase, there may be errors.

Does this look like it's going in the right direction?

Questions:

 - Would we want a `emacs-search-forward-current` for parity? Admittedly, I don't see why you'd want to start searching the history forwards, but since `emacs-search-forward` exists, I guess there must be some reason.
 
 - To be able to  test the utility of this properly, I'd have to bind the keys how I'm used to them from fish. I'd like:
   - `emacs-search-backward-current` if you are **not** already in emacs search mode.
   - `srch-continue-backward` if you **are** already in emacs search mode.

If you try that with:
```
bindkey -e '\U' emacs-search-backward-current
bindkey -e '\U' srch-continue-backward
```

Then you don't get what you expected. What confuses me is that by default `\^R` is bound to different actions depending on the mode. Is it possible?

Thanks