### PR TITLE
Very quick attempt at not re-reading history before each prompt.

### DIFF
--- a/history.c
+++ b/history.c
@@ -119,6 +119,8 @@ static time_t now = (time_t) -1;
 /* If true, the history is locked, that is, readonly. */
 static bool hist_lock = false;
 
+/* Whether to re-read the history file before each prompt */
+static bool histreread = true;
 
 struct search_result_T {
     histlink_T *prev, *next;
@@ -824,7 +826,7 @@ void update_history(bool refresh)
     fpos_t pos;
     long rev;
 
-    if (histfile == NULL)
+    if ((histfile == NULL) || (!histreread))
         return;
     assert(!hist_lock);
 
@@ -966,6 +968,9 @@ void maybe_init_history(void)
         if (xwcstoul(vhistrmdup, 10, &rmdup))
             histrmdup = (rmdup <= histsize) ? rmdup : histsize;
     }
+
+    /* set `histreread' */
+    histreread = !shopt_nohistreread;
 
     update_time();
 

--- a/option.c
+++ b/option.c
@@ -201,6 +201,9 @@ bool shopt_le_compdebug = false;
 bool shopt_le_trimright = false;
 #endif
 
+/* If set, the history file is not re-read before each prompt.
+ * Corresponds to the --nohistreread option. */
+bool shopt_nohistreread = false;
 
 struct option_T {
     wchar_t shortopt_enable, shortopt_disable;
@@ -251,6 +254,7 @@ static const struct option_T shell_options[] = {
     { L'l', 0,    L"login",          &is_login_shell,       false, },
     { 0,    0,    L"markdirs",       &shopt_markdirs,       true, },
     { L'm', 0,    L"monitor",        &do_job_control,       true, },
+    { 0,    0,    L"nohistreread",   &shopt_nohistreread,   true, },
     { L'b', 0,    L"notify",         &shopt_notify,         true, },
 #if YASH_ENABLE_LINEEDIT
     { 0,    0,    L"notifyle",       &shopt_notifyle,       true, },

--- a/option.h
+++ b/option.h
@@ -60,6 +60,7 @@ extern _Bool shopt_le_visiblebell, shopt_le_promptsp, shopt_le_alwaysrp,
     shopt_le_predict, shopt_le_predictempty, shopt_le_compdebug,
     shopt_le_trimright;
 #endif
+extern _Bool shopt_nohistreread;
 
 /* Whether or not this shell process is doing job control right now. */
 #define doing_job_control_now  (do_job_control && ttyfd >= 0)


### PR DESCRIPTION
This is a quick attempt to address one of the suggestions for https://github.com/magicant/yash/issues/25.

> I was thinking of adding two options to change the shell's behavior. The first option can be used to disable the shell from reading new commands from the history file written by other shell instances. The second option makes the shell write the history when the shell exits rather than each time a new command is entered.
>
> For now, I'm considering adding only the first option rather than implementing the both options at once.

This implements the first option only. Is this the kind of thing we want?

If we like this, I think we'd also want a builtin and/or bindable to force reread the history, for those instances where you really do want the history from another shell.

(I notice that you are already using advisory locking on the history file, so you could probably implement something better, where history from other shells is inherited immediately, but the current shell's history are prioritised. The change here however is much simpler)

What do you think?