### PR TITLE
Use table for packages

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,15 +63,52 @@ Currently, yash is mainly tested on Fedora.
 <p>The source tarball can be downloaded from the
 <a href="//github.com/magicant/yash/releases">Releases page</a>.
 (See the <a href="releases.html">release list</a> or older versions.)
-<p>On <a href="https://getfedora.org/">Fedora</a>, the yash package can be
-installed by <kbd>sudo dnf install yash</kbd>.
-On <a href="https://www.debian.org/">Debian</a> and
-<a href="https://www.ubuntu.com/">Ubuntu</a>, the yash package can be installed
-by <kbd>sudo apt-get install yash</kbd>.
-For macOS, <a href="https://www.macports.org/">MacPorts</a> and
-<a href="https://brew.sh/">Homebrew</a> provide yash installation.
-On NetBSD and other supported platforms, yash is available through
-<a href="https://pkgsrc.org/">pkgsrc</a>.
+<p>Yash is availible in most package managers, here is how to install Yash:
+ <table>
+   <tr>
+    <th>Package Manager</th>
+    <th>Unix System</th>
+    <th>Command</th>
+  </tr>
+   <tr>
+    <th>DNF</th>
+    <th><a href="https://getfedora.org/">Fedora</a></th>
+    <th><kbd>dnf install yash</kbd></th>
+  </tr>
+   <tr>
+    <th>APT</th>
+    <th>
+      <a href="https://www.debian.org/">Debian</a> /
+      <a href="https://www.ubuntu.com/">Ubuntu</a></th>
+    <th><kbd>apt install yash</kbd></th>
+   </tr>
+   <tr>
+    <th>MacPorts</th>
+        <th><a href="https://www.apple.com/macos/">macOS</a></th>
+    <th><kbd>port install yash</kbd></th>
+   </tr>
+   <tr>
+    <th>Homebrew</th>
+    <th><a href="https://www.apple.com/macos/">macOS</a></th>
+    <th><kbd>brew install yash</kbd></th>
+   </tr>
+   <tr>
+    <th>pkg</th>
+    <th><a href="https://www.freebsd.org/">FreeBSD</a></th>
+    <th><kbd>pkg install yash</kbd></th>
+   </tr>
+   <tr>
+    <th>pkgin</th>
+    <th><a href="https://www.netbsd.org/">NetBSD</a></th>
+    <th><kbd>pkgin install yash</kbd></th>
+   </tr>
+   <tr>
+    <th>pkg_add</th>
+    <th><a href="https://www.openbsd.org/">OpenBSD</a></th>
+    <th><kbd>pkg_add yash</kbd></th>
+  </tr>
+  </table>
+
 <p>After installation, enter <kbd>yash</kbd> in the terminal to start yash.
 The <a href="doc/">manual</a> can be viewed by <kbd>man yash</kbd>.
 


### PR DESCRIPTION
Use table for packages to make it easier for users to find how to install Yash for their Unix system.