### PR TITLE
Add file path to error message

### DIFF
--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -49,7 +49,7 @@ test:
 	@tail -n 6 $(SUMMARY) | grep ^FAILED | \
 		(read _ fail_count && \
 		if [ "$$fail_count" -ne 0 ]; then \
-			echo See tests/$(SUMMARY) for details; \
+			echo See $(subdir)/$(SUMMARY) for details; \
 			exit 1; \
 		fi)
 test-posix:

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -49,7 +49,7 @@ test:
 	@tail -n 6 $(SUMMARY) | grep ^FAILED | \
 		(read _ fail_count && \
 		if [ "$$fail_count" -ne 0 ]; then \
-			echo See $(SUMMARY) for details; \
+			echo See tests/$(SUMMARY) for details; \
 			exit 1; \
 		fi)
 test-posix:


### PR DESCRIPTION
Make the location of summary.log clearer but appending the folder in which the file is in to the error message.