### PR TITLE
Git completion fixes

### DIFF
--- a/share/completion/git-merge
+++ b/share/completion/git-merge
@@ -36,6 +36,7 @@ function completion/git::merge:arg {
 function completion/git::merge:getopt {
         OPTIONS=("$OPTIONS" #>#
         "--commit; commit the merge result automatically"
+        "--continue; continue the current merge"
         "--ff; fast-forward if possible"
         "--ff-only; allow fast-forward only"
         "--log::; specify the number of commits in the merged branch of which the messages are reused"
@@ -52,7 +53,6 @@ function completion/git::merge:getopt {
         "s: --strategy:; specify the merge strategy"
         "X: --strategy-option:; specify a strategy-specific option"
         "v --verbose; output additional information"
-        "--continue; continue the current merge"
         ) #<#
 }
 

--- a/share/completion/git-merge
+++ b/share/completion/git-merge
@@ -52,6 +52,7 @@ function completion/git::merge:getopt {
         "s: --strategy:; specify the merge strategy"
         "X: --strategy-option:; specify a strategy-specific option"
         "v --verbose" # TODO description
+        "--continue; continue the current merge"
         ) #<#
 }
 

--- a/share/completion/git-merge
+++ b/share/completion/git-merge
@@ -51,7 +51,7 @@ function completion/git::merge:getopt {
         "--stat --summary; print a diffstat"
         "s: --strategy:; specify the merge strategy"
         "X: --strategy-option:; specify a strategy-specific option"
-        "v --verbose" # TODO description
+        "v --verbose; output additional information"
         "--continue; continue the current merge"
         ) #<#
 }

--- a/share/completion/git-push
+++ b/share/completion/git-push
@@ -31,7 +31,7 @@ function completion/git::push:arg {
         "u --set-upstream; make pushed branches remote-tracking"
         "--tags; push all local tags"
         "--thin; send a thin pack to reduce traffic"
-        "v --verbose" # TODO description
+        "v --verbose; output additional information"
         "--verify; enable the pre-push hook"
         ) #<#
 

--- a/share/completion/git-rebase
+++ b/share/completion/git-rebase
@@ -67,7 +67,7 @@ function completion/git::rebase:getopt {
         "s: --strategy:; specify the merge strategy"
         "x: --exec:; insert an \"exec\" line with the specified command after each commit (with -i)"
         "X: --strategy-option:; specify a strategy-specific option"
-        "v --verbose" # TODO description
+        "v --verbose; output additional information"
         "--verify; run the pre-rebase hook"
         ) #<#
         if command -vf completion/git::apply:getopt >/dev/null 2>&1 ||


### PR DESCRIPTION
Add completion for `git-merge`'s `--continue` flag and also add descriptions for `git-merge`, `git-push`, and `git-rebase`'s `--verbose` flag.