### PR TITLE
tests/job-y.tst: Account for root PS1.

### DIFF
--- a/tests/job-y.tst
+++ b/tests/job-y.tst
@@ -1,13 +1,21 @@
 # job-y.tst: yash-specific test of job control
 ../checkfg || skip="true" # %REQUIRETTY%
 
+user_id="$(id -u)"
+
 # This test case first creates a background job that immediately exits, then
 # waits for the job to finish, sending a null signal to the job to poll if the
 # job is still running. A subshell starts another job and waits for it to finish
 # to make sure the main shell process receives the SIGCHLD signal and examines
 # the latest job status. The test case checks if the job is reported as done
 # before the prompt for the next line is displayed.
-test_e 'interactive shell reports job status before prompt' -im
+(
+if [ "$user_id" -eq 0 ]; then
+    skip="true"
+fi
+
+(
+test_e 'interactive shell reports job status before prompt (non-root)' -im
 echo >&2; sleep 0& while kill -0 $! 2>/dev/null; do :; done; (sleep 0& wait)
 echo done >&2; exit
 __IN__
@@ -15,6 +23,25 @@ $
 [1] + Done                 sleep 0
 $ done
 __ERR__
+)
+)
+
+(
+if [ "$user_id" -ne 0 ]; then
+    skip="true"
+fi
+
+(
+test_e 'interactive shell reports job status before prompt (root)' -im
+echo >&2; sleep 0& while kill -0 $! 2>/dev/null; do :; done; (sleep 0& wait)
+echo done >&2; exit
+__IN__
+# 
+[1] + Done                 sleep 0
+# done
+__ERR__
+)
+)
 
 mkfifo sync
 


### PR DESCRIPTION
The first test in `job-y.tst` currently fails invariably for the root user because it expects a `$PS1` of `$ `. Add a separate test for the root user expecting a `$PS1` of `# `.