### PR TITLE
Redefine Actions workflow

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -16,9 +16,7 @@ jobs:
         sudo apt-get install asciidoc gettext libncurses-dev
     - name: configure
       run: ./configure
-    - name: make
-      run: make
-    - name: make check
-      run: make check
     - name: make distcheck
-      run: make distcheck
+      run: make -j$(nproc) distcheck
+    - name: make check as root
+      run: sudo make -j$(nproc) check


### PR DESCRIPTION
- Remove make and make check steps since they are included in make distcheck
- Add make check as root step to make sure that the tests succeed when run as root
- Add -j$(nproc) to make invocations to speed up the build