### PR TITLE
Change false, pwd, and true to substitutive built-ins

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -104,9 +104,9 @@ void init_builtin(void)
 
     /* defined in "builtin.c" */
     DEFBUILTIN(":", true_builtin, BI_SPECIAL, colon_help, colon_syntax, NULL);
-    DEFBUILTIN("true", true_builtin, BI_MANDATORY, true_help, true_syntax,
+    DEFBUILTIN("true", true_builtin, BI_SUBSTITUTIVE, true_help, true_syntax,
             NULL);
-    DEFBUILTIN("false", false_builtin, BI_MANDATORY, false_help, false_syntax,
+    DEFBUILTIN("false", false_builtin, BI_SUBSTITUTIVE, false_help, false_syntax,
             NULL);
 #if YASH_ENABLE_HELP
     DEFBUILTIN("help", help_builtin, BI_ELECTIVE, help_help, help_syntax,
@@ -119,7 +119,7 @@ void init_builtin(void)
     /* defined in "path.c" */
     DEFBUILTIN("cd", cd_builtin, BI_MANDATORY, cd_help, cd_syntax,
             cd_options);
-    DEFBUILTIN("pwd", pwd_builtin, BI_MANDATORY, pwd_help, pwd_syntax,
+    DEFBUILTIN("pwd", pwd_builtin, BI_SUBSTITUTIVE, pwd_help, pwd_syntax,
             pwd_options);
     DEFBUILTIN("hash", hash_builtin, BI_MANDATORY, hash_help, hash_syntax,
             hash_options);

--- a/tests/builtins-p.tst
+++ b/tests/builtins-p.tst
@@ -329,10 +329,6 @@ test_OE -e 0 'intrinsic built-in command can be invoked without $PATH'
 command :
 __IN__
 
-test_OE 'intrinsic built-in false can be invoked without $PATH'
-false
-__IN__
-
 # Tested in builtins-y.tst.
 #test_OE -e 0 'intrinsic built-in fc can be invoked without $PATH'
 #test_OE -e 0 'intrinsic built-in fg can be invoked without $PATH'
@@ -353,17 +349,9 @@ test_OE -e 0 'intrinsic built-in kill can be invoked without $PATH'
 kill -0 $$
 __IN__
 
-test_E -e 0 'intrinsic built-in pwd can be invoked without $PATH'
-pwd
-__IN__
-
 test_OE -e 0 'intrinsic built-in read can be invoked without $PATH'
 read a
 _this_line_is_read_by_the_read_built_in_
-__IN__
-
-test_OE -e 0 'intrinsic built-in true can be invoked without $PATH'
-true
 __IN__
 
 test_E -e 0 'intrinsic built-in type can be invoked without $PATH'

--- a/tests/command-p.tst
+++ b/tests/command-p.tst
@@ -24,9 +24,9 @@ __IN__
 a
 __OUT__
 
-test_OE -e n 'command ignores function (mandatory built-in)'
-false () { true; }
-command false
+test_OE -e 0 'command ignores function (mandatory built-in)'
+alias () { false; }
+command alias
 __IN__
 
 test_E -e 0 'command ignores function (substitutive built-in)'

--- a/tests/command-y.tst
+++ b/tests/command-y.tst
@@ -81,22 +81,19 @@ unset: a special built-in
 __OUT__
 
 test_oE -e 0 'describing mandatory built-ins (-V)'
-command -V alias bg cd command false fg getopts hash jobs kill pwd read true \
+command -V alias bg cd command fg getopts hash jobs kill read \
     type umask unalias wait
 __IN__
 alias: a mandatory built-in
 bg: a mandatory built-in
 cd: a mandatory built-in
 command: a mandatory built-in
-false: a mandatory built-in
 fg: a mandatory built-in
 getopts: a mandatory built-in
 hash: a mandatory built-in
 jobs: a mandatory built-in
 kill: a mandatory built-in
-pwd: a mandatory built-in
 read: a mandatory built-in
-true: a mandatory built-in
 type: a mandatory built-in
 umask: a mandatory built-in
 unalias: a mandatory built-in
@@ -133,8 +130,38 @@ if ! testee -c 'command -bv echo' >/dev/null; then
     skip="true"
 fi
 
-test_OE 'describing substitutive built-in (-V)'
+test_OE 'describing substitutive built-in echo (-V)'
 command -V echo | grep -v "^echo: a substitutive built-in "
+__IN__
+)
+
+(
+if ! testee -c 'command -bv false' >/dev/null; then
+    skip="true"
+fi
+
+test_OE 'describing substitutive built-in false (-V)'
+command -V false | grep -v "^false: a substitutive built-in "
+__IN__
+)
+
+(
+if ! testee -c 'command -bv true' >/dev/null; then
+    skip="true"
+fi
+
+test_OE 'describing substitutive built-in true (-V)'
+command -V true | grep -v "^true: a substitutive built-in "
+__IN__
+)
+
+(
+if ! testee -c 'command -bv pwd' >/dev/null; then
+    skip="true"
+fi
+
+test_OE 'describing substitutive built-in pwd (-V)'
+command -V pwd | grep -v "^pwd: a substitutive built-in "
 __IN__
 )
 


### PR DESCRIPTION
1. Replaced the definition of the commands from `BI_MANDATORY` to `BI_SUBSTITUTIVE`
2. Updated the test cases to reflect the changes

Fixes #96 
