### PR TITLE
Reject empty operand in cd built-in

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -19,6 +19,8 @@
       of mode.
     - The `true`, `false`, and `pwd` built-ins are now substitutive
       built-ins.
+    - The `cd` built-in now exits with status code 5, when an empty 
+      operand is supplied.
   - [line-editing] Updated the completion scripts to support Git
     2.48.1.
   - [line-editing] Added the completion script for `git-mv`.

--- a/doc/_cd.txt
+++ b/doc/_cd.txt
@@ -106,7 +106,8 @@ specified either, the default is the link:params.html#sv-home[home directory].
 * If {{directory}} cannot be processed because of an unset or empty
   link:params.html#sv-home[+HOME+] or link:params.html#sv-oldpwd[+OLDPWD+],
   the exit status is 4.
-* If the command arguments are invalid, the exit status is 5.
+* If the command arguments are invalid or if an empty operand is supplied
+  for {{directory}}, the exit status is 5.
 
 If and only if the exit status is 2 or larger, the working directory is not
 changed.

--- a/path.c
+++ b/path.c
@@ -1232,6 +1232,11 @@ int change_directory(
 
     assert(!logical || !ensure_pwd);
 
+    if ( newpwd[0] == L'\0' ) {
+	xerror(0, Ngt("empty directory"));
+	return 5;
+    }
+
     /* get the current value of $PWD as `origpwd' */
     origpwd = getvar(L VAR_PWD);
     if (origpwd == NULL || origpwd[0] != L'/') {

--- a/path.c
+++ b/path.c
@@ -1233,7 +1233,7 @@ int change_directory(
     assert(!logical || !ensure_pwd);
 
     if (newpwd[0] == L'\0') {
-	xerror(0, Ngt("empty directory"));
+	xerror(0, Ngt("empty directory name"));
 	return 5;
     }
 

--- a/path.c
+++ b/path.c
@@ -1232,7 +1232,7 @@ int change_directory(
 
     assert(!logical || !ensure_pwd);
 
-    if ( newpwd[0] == L'\0' ) {
+    if (newpwd[0] == L'\0') {
 	xerror(0, Ngt("empty directory"));
 	return 5;
     }

--- a/tests/cd-y.tst
+++ b/tests/cd-y.tst
@@ -21,7 +21,7 @@ __ERR__
 test_Oe -e 5 'empty operand'
 cd ''
 __IN__
-cd: empty directory
+cd: empty directory name
 __ERR__
 
 testcase "$LINENO" 'unset PWD' \

--- a/tests/cd-y.tst
+++ b/tests/cd-y.tst
@@ -18,16 +18,11 @@ __IN__
 cd: $HOME is not set
 __ERR__
 
-testcase "$LINENO" 'empty operand is like "."' \
-    3<<\__IN__ 5</dev/null 4<<__OUT__
-unset CDPATH
+test_Oe -e 5 'empty operand'
 cd ''
-echo ---
-pwd
 __IN__
----
-$ORIGPWD
-__OUT__
+cd: empty directory
+__ERR__
 
 testcase "$LINENO" 'unset PWD' \
     3<<\__IN__ 5</dev/null 4<<__OUT__


### PR DESCRIPTION
Made the following changes:
- [x] Update the implementation to add a check for an empty operand. The exit status should be 5 on error.
- [x] Update the test scripts.
- [x] Update the user manual.
- [x] Update the NEWS.

Fixes #104 