### PR TITLE
Add macOS workaround for test of suspended job

### DIFF
--- a/tests/job-y.tst
+++ b/tests/job-y.tst
@@ -53,6 +53,8 @@ cat sync
 wait $pid
 __IN__
 
+macos_kill_workaround
+
 : TODO This test case is flaky for unknown reasons <<'__IN__'
 # This is a POSIX requirement, but this test case depends on the shell's
 # behavior that runs all pipeline components in child processes.


### PR DESCRIPTION
The GitHub Actions workflow for macOS failed, implying that we should apply the workaround for this test case, too.
https://github.com/magicant/yash/actions/runs/14156221168/attempts/1