### PR TITLE
Filter '.' and '..' from wglob results

### DIFF
--- a/path.c
+++ b/path.c
@@ -1053,6 +1053,8 @@ void wglob_scandir_entry(
             case WGLOB_MATCH:
                 if (name[0] == '\0')
                     continue;
+                if (strcmp(name, "..") == 0 || strcmp(name, ".") == 0)
+                    continue;
                 if (xfnm_match(c->value.match.pattern, name) != 0)
                     continue;
                 if (i + 1 < s->pattern.length) // has a next component?

--- a/tests/path-y.tst
+++ b/tests/path-y.tst
@@ -108,6 +108,15 @@ anotherdir/file
 dir/dir/file
 __OUT__
 
+# testing that . and .. are filtered out
+test_oE 'extendedglob on, dotglob on: effect' --dotglob --extendedglob
+echo .**/*
+echo .***/*
+__IN__
+.dir .dir/dir .dir/dir/file .dir/file anotherdir anotherdir/file anotherdir/loop dir dir/.dir dir/.dir/file dir/dir dir/dir/.link dir/dir/file dir/dir/link
+.dir .dir/dir .dir/dir/file .dir/file anotherdir anotherdir/file anotherdir/loop anotherdir/loop/.dir anotherdir/loop/.dir/file anotherdir/loop/dir anotherdir/loop/dir/.link anotherdir/loop/dir/file anotherdir/loop/dir/link dir dir/.dir dir/.dir/file dir/dir dir/dir/.link dir/dir/.link/file dir/dir/.link/loop dir/dir/file dir/dir/link dir/dir/link/file dir/dir/link/loop
+__OUT__
+
 )
 
 (

--- a/tests/path-y.tst
+++ b/tests/path-y.tst
@@ -117,6 +117,12 @@ __IN__
 .dir .dir/dir .dir/dir/file .dir/file anotherdir anotherdir/file anotherdir/loop anotherdir/loop/.dir anotherdir/loop/.dir/file anotherdir/loop/dir anotherdir/loop/dir/.link anotherdir/loop/dir/file anotherdir/loop/dir/link dir dir/.dir dir/.dir/file dir/dir dir/dir/.link dir/dir/.link/file dir/dir/.link/loop dir/dir/file dir/dir/link dir/dir/link/file dir/dir/link/loop
 __OUT__
 
+# testing that . filter is not applied to literal matches
+test_oE 'extendedglob on: literal match' --dotglob --extendedglob
+echo **/.
+__IN__
+. anotherdir/. dir/. dir/dir/.
+__OUT__
 )
 
 (

--- a/tests/path-y.tst
+++ b/tests/path-y.tst
@@ -29,7 +29,7 @@ test_oE 'dotglob on: effect' --dotglob
 echo *
 echo ?dotglob
 __IN__
-. .. .dotglob
+.dotglob
 .dotglob
 __OUT__
 


### PR DESCRIPTION
Addresses issue #97 

Iterate over the results from `wglob_search` and remove any verbatim match of `.` and `..`.

NOTE: This does not apply to results like `component/..` or recursive globs. This is a naive solution. Perhaps a more general solution could be done in `wglob_search`?

I did a small optimization by conditionally stopping the loop as soon as two results are removed. This relies on the assumption that only two results from `glob_search` would match `.` or `..`.
The filtering happens after the results are sorted, this likely limits the number of iterations, but this is another assumption.