### PR TITLE
Document hashondef and nolog options for POSIX.1-2024

### DIFF
--- a/doc/_set.txt
+++ b/doc/_set.txt
@@ -275,8 +275,13 @@ The options defined in the standard are:
 - +-o nolog+
 - +-o vi+
 
-Yash does not support the nolog option, which prevents
+Yash does not support the +nolog+ option. This option prevented
 link:syntax.html#funcdef[function definitions] from being added to
-link:interact.html#history[command history].
+link:interact.html#history[command history] in old versions of Korn shell, but
+is no longer supported by any popular shell.
+
+The behavior of the +hash-on-def+ option in yash is based on POSIX.1-2001.
+Many existing shells implement this option with different behavior, and
+POSIX.1-2024 no longer imposes any behavior on this option.
 
 // vim: set filetype=asciidoc textwidth=78 expandtab:

--- a/doc/ja/_set.txt
+++ b/doc/ja/_set.txt
@@ -191,6 +191,9 @@ POSIX 規格に定義されているオプションは限られています。�
 - +-o nolog+
 - +-o vi+
 
-POSIX ではこのほかに、{zwsp}link:syntax.html#funcdef[関数定義]を{zwsp}link:interact.html#history[コマンド履歴]に登録しないようにする +-o nolog+ オプションを規定していますが、yash はこれをサポートしていません。
+Yash は +nolog+ オプションをサポートしていません。
+このオプションは古い Korn シェルで{zwsp}link:syntax.html#funcdef[関数定義]を{zwsp}link:interact.html#history[コマンド履歴]に登録しないようにする機能がありましたが、現在ほとんどのシェルではサポートされていません。
+
+Yash の +hash-on-def+ オプションの動作は、POSIX.1-2001 に基づいています。既存の多くのシェルはこのオプションを異なる動作で実装しており、POSIX.1-2024 ではこのオプションの動作は規定されなくなりました。
 
 // vim: set filetype=asciidoc expandtab:


### PR DESCRIPTION
POSIX.1-2024 no longer defines the behavior of the `-h` and `-o nolog` options because they are implemented differently in different shells. This commit updates the documentation to reflect this change.

## Summary by Copilot

This pull request updates the documentation for the `nolog` and `hash-on-def` options in both English and Japanese files to clarify their behavior and compatibility with POSIX standards and other shells.

### Documentation updates:

* [`doc/_set.txt`](diffhunk://#diff-c3d6462ed8240f8350064b0caeb9aafc167f95ea236262a4e0e00ffb21ca8b19L278-R285): Updated the description of the `nolog` option to clarify its historical behavior in older Korn shells and its lack of support in modern shells. Added details about the `hash-on-def` option, explaining its behavior based on POSIX.1-2001 and noting that POSIX.1-2024 no longer specifies its behavior.

* [`doc/ja/_set.txt`](diffhunk://#diff-79bd6dcf4880fb4715087323ef9c008693524e074fae1a38826430d3aa4a4fffL194-R198): Provided a similar update in Japanese, explaining the historical behavior of the `nolog` option and its lack of support in most modern shells. Also added an explanation of the `hash-on-def` option's behavior and its evolution in POSIX standards.