### PR TITLE
Update environment when arrays are mutated using -i and -d

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -1583,12 +1583,12 @@ static bool can_make_readonly(const wchar_t *name)
 #if YASH_ENABLE_ARRAY
 static int array_dump_all(const wchar_t *argv0);
 static void array_remove_elements(
-        variable_T *array, size_t count, void *const *indexwcss)
+        const wchar_t*, variable_T *array, size_t count, void *const *indexwcss)
     __attribute__((nonnull));
 static int compare_long(const void *lp1, const void *lp2)
     __attribute__((nonnull,pure));
 static void array_insert_elements(
-        variable_T *array, size_t count, void *const *values)
+        const wchar_t*, variable_T *array, size_t count, void *const *values)
     __attribute__((nonnull));
 static void array_set_element(const wchar_t *name, variable_T *array,
         const wchar_t *indexword, const wchar_t *value)
@@ -2102,10 +2102,10 @@ int array_builtin(int argc, void **argv)
             return Exit_FAILURE;
         switch (options) {
             case DELETE:
-                array_remove_elements(array, argc - xoptind, &argv[xoptind]);
+                array_remove_elements(name, array, argc - xoptind, &argv[xoptind]);
                 break;
             case INSERT:
-                array_insert_elements(array, argc - xoptind, &argv[xoptind]);
+                array_insert_elements(name, array, argc - xoptind, &argv[xoptind]);
                 break;
             case SET:
                 array_set_element(
@@ -2148,7 +2148,7 @@ int array_dump_all(const wchar_t *argv0)
  * `count' is the number of elements in `indexwcss'.
  * An error message is printed to the standard error on error. */
 void array_remove_elements(
-        variable_T *array, size_t count, void *const *indexwcss)
+        const wchar_t *name, variable_T *array, size_t count, void *const *indexwcss)
 {
     size_t extended_count = count;
     if (extended_count == 0)
@@ -2195,6 +2195,9 @@ void array_remove_elements(
     }
     array->v_valc = list.length;
     array->v_vals = pl_toary(&list);
+
+    if (array->v_type & VF_EXPORT)
+        update_environment(name);
 }
 
 int compare_long(const void *lp1, const void *lp2)
@@ -2211,7 +2214,7 @@ int compare_long(const void *lp1, const void *lp2)
  * string.
  * An error message is printed to the standard error on error. */
 void array_insert_elements(
-        variable_T *array, size_t count, void *const *values)
+        const wchar_t *name, variable_T *array, size_t count, void *const *values)
 {
     long index;
 
@@ -2247,6 +2250,9 @@ void array_insert_elements(
         list.contents[uindex + i] = xwcsdup(list.contents[uindex + i]);
     array->v_valc = list.length;
     array->v_vals = pl_toary(&list);
+
+    if (array->v_type & VF_EXPORT)
+        update_environment(name);
 }
 
 /* Sets the value of the specified element of the array.


### PR DESCRIPTION
When an array (e.g. PATH) is exported, it is meant to be available as the concatenation of all the elements with `:`s between them.
For example: `array SOME a b c; export SOME` should produce `env` output like `SOME=a:b:c`

If one mutates the array using simple assignments (`SOME=("$SOME" d)`) or `array SOME "$SOME" d` or using `array -s`, the environment variable is updated accordingly.
However, if one mutates the array using `array -i` or `array -d`, this change is not reflected, necessitating a later `array SOME "$SOME"` or similar construction to make the export "take effect".

This fixes this by making `array -i` and `array -d` update the environment table.