### PR TITLE
Add completion for 'typst'

### DIFF
--- a/share/completion/typst
+++ b/share/completion/typst
@@ -1,0 +1,94 @@
+function completion/typst {
+
+        typeset OPTIONS ARGOPT PREFIX
+
+        OPTIONS=( #>#
+        "h --help; show help"
+        "V --version; show version"
+        "--color:; colorize output (auto, always, never)"
+        "--cert:; TLS certificate chain file"
+        ) #<#
+
+        command -f completion//parseoptions -n
+        case $ARGOPT in
+                (-)
+                        command -f completion//completeoptions
+                        ;;
+                (--color)
+                        complete -P "$PREFIX" auto always never
+                        ;;
+                (--cert)
+                        complete -P "$PREFIX" -f
+                        ;;
+                ('')
+                        # find first non-option argument, which is subcommand
+                        typeset OPTIND=2 typcmd=
+                        while [ $OPTIND -le ${WORDS[#]} ]; do
+                                case ${WORDS[OPTIND]} in
+                                        (--color)
+                                                OPTIND=$((OPTIND+1))
+                                                ;;
+                                        (--color=*)
+                                                ;;
+                                        (--cert)
+                                                OPTIND=$((OPTIND+1))
+                                                ;;
+                                        (--cert=*)
+                                                ;;
+                                        (-?*)
+                                                ;;
+                                        (*)
+                                                typcmd=${WORDS[OPTIND]}
+                                                break
+                                                ;;
+                                esac
+                                OPTIND=$((OPTIND+1))
+                        done
+
+                        if [ $OPTIND -le ${WORDS[#]} ]; then
+                                # some short aliases
+                                # TODO: lookup if others exist
+                                case $typcmd in
+                                        (c) typcmd=compile;;
+                                        (w) typcmd=watch;;
+                                esac
+                                OPTIND=$((OPTIND+1))
+
+                                # complete args of subcommand
+                                typeset OLDWORDS
+                                OLDWORDS=("$WORDS")
+                                WORDS=("${WORDS[1]}" "${WORDS[OPTIND,-1]}")
+
+                                # since all commands have -h/--help option
+                                if [ ${WORDS[#]} -le 1 ]; then
+                                        case $TARGETWORD in (-*)
+                                                complete -- --help -h
+                                        esac
+                                fi
+
+                                if { command -vf "completion/typst::$typcmd:arg" ||
+                                      . -AL "completion/typst-$typcmd"; } >/dev/null 2>&1
+                                then
+                                        command -f "completion/typst::$typcmd:arg"
+                                else
+                                        complete -P "$PREFIX" -f
+                                fi
+                        else
+                                # if no subcommand yet, then: complete subcommand names
+                                command -f completion/typst::completecmd
+                        fi
+                        ;;
+        esac
+}
+
+function completion/typst::completecmd {
+        complete -P "$PREFIX" -D "compile a document" compile c
+        complete -P "$PREFIX" -D "watch and recompile on changes" watch w
+        complete -P "$PREFIX" -D "initialize a new project" init
+        complete -P "$PREFIX" -D "query elements from a document" query
+        complete -P "$PREFIX" -D "list available fonts" fonts
+        complete -P "$PREFIX" -D "update packages" update
+        complete -P "$PREFIX" -D "show help for subcommands" help
+}
+
+# vim: set ft=sh ts=8 sts=8 sw=8 et:

--- a/share/completion/typst-compile
+++ b/share/completion/typst-compile
@@ -1,0 +1,53 @@
+function completion/typst::compile:arg {
+
+        OPTIONS=( #>#
+        "j: --jobs:; number of parallel jobs"
+        "--root:; project root directory"
+        "--input:; additional input"
+        "--font-path:; font search path"
+        "--ignore-system-fonts; ignore system fonts"
+        "--package-path:; package search path"
+        "--package-cache-path:; package cache directory"
+        "--features:; enable features (e.g. html)"
+        "--diagnostic-format:; diagnostics format (human, short)"
+        "f: --format:; output format (pdf, png, svg, html)"
+        "--creation-timestamp:; creation timestamp"
+        "--pages:; pages to export"
+        "--pdf-standard:; PDF standard (1.7, a-2b, a-3b)"
+        "--ppi:; output PPI"
+        "--make-deps:; generate dependency file"
+        "--open; open output after running"
+        "--timings:; print timing info"
+        ) #<#
+
+        command -f completion//parseoptions -n
+        case $ARGOPT in
+                (-)
+                        command -f completion//completeoptions
+                        ;;
+                (--root|--font-path|--package-path|--package-cache-path)
+                        complete -P "$PREFIX" -S / -T -d
+                        ;;
+                (--make-deps|--timings)
+                        complete -P "$PREFIX" -f
+                        ;;
+                (f|--format)
+                        complete -P "$PREFIX" pdf png svg html
+                        ;;
+                (--pdf-standard)
+                        complete -P "$PREFIX" 1.7 a-2b a-3b
+                        ;;
+                (--features)
+                        complete -P "$PREFIX" html
+                        ;;
+                (--diagnostic-format)
+                        complete -P "$PREFIX" human short
+                        ;;
+                ('')
+                        # <INPUT> [OUTPUT]
+                        complete -P "$PREFIX" -f
+                        ;;
+        esac
+}
+
+# vim: set ft=sh ts=8 sts=8 sw=8 et:

--- a/share/completion/typst-fonts
+++ b/share/completion/typst-fonts
@@ -1,0 +1,24 @@
+function completion/typst::fonts:arg {
+
+        OPTIONS=( #>#
+        "--font-path:; font search path"
+        "--ignore-system-fonts; ignore system fonts"
+        "--variants; list font variants"
+        ) #<#
+
+        command -f completion//parseoptions -n
+        case $ARGOPT in
+                (-)
+                        command -f completion//completeoptions
+                        ;;
+                (--font-path)
+                        complete -P "$PREFIX" -S / -T -d
+                        ;;
+                ('')
+                        # no positional args
+                        :
+                        ;;
+        esac
+}
+
+# vim: set ft=sh ts=8 sts=8 sw=8 et:

--- a/share/completion/typst-help
+++ b/share/completion/typst-help
@@ -1,0 +1,6 @@
+function completion/typst::help:arg {
+        # no options just complete subcommand names
+        command -f completion/typst::completecmd
+}
+
+# vim: set ft=sh ts=8 sts=8 sw=8 et:

--- a/share/completion/typst-init
+++ b/share/completion/typst-init
@@ -5,7 +5,7 @@ function completion/typst::init:arg {
         "--package-cache-path:; package cache directory"
         ) #<#
 
-        command -f completion//parseoptions -n
+        command -f completion//parseoptions
         case $ARGOPT in
                 (-)
                         command -f completion//completeoptions
@@ -14,7 +14,10 @@ function completion/typst::init:arg {
                         complete -P "$PREFIX" -S / -T -d
                         ;;
                 ('')
-                        complete -P "$PREFIX" -S / -T -d
+                        command -f completion//getoperands
+                        if [ "${WORDS[#]}" -eq 1 ]; then
+                                complete -P "$PREFIX" -S / -T -d
+                        fi
                         ;;
         esac
 }

--- a/share/completion/typst-init
+++ b/share/completion/typst-init
@@ -1,0 +1,22 @@
+function completion/typst::init:arg {
+
+        OPTIONS=( #>#
+        "--package-path:; package search path"
+        "--package-cache-path:; package cache directory"
+        ) #<#
+
+        command -f completion//parseoptions -n
+        case $ARGOPT in
+                (-)
+                        command -f completion//completeoptions
+                        ;;
+                (--package-path|--package-cache-path)
+                        complete -P "$PREFIX" -S / -T -d
+                        ;;
+                ('')
+                        complete -P "$PREFIX" -S / -T -d
+                        ;;
+        esac
+}
+
+# vim: set ft=sh ts=8 sts=8 sw=8 et:

--- a/share/completion/typst-query
+++ b/share/completion/typst-query
@@ -1,0 +1,43 @@
+function completion/typst::query:arg {
+
+        OPTIONS=( #>#
+        "j: --jobs:; number of parallel jobs"
+        "--root:; project root directory"
+        "--input:; additional input"
+        "--font-path:; font search path"
+        "--ignore-system-fonts; ignore system fonts"
+        "--package-path:; package search path"
+        "--package-cache-path:; package cache directory"
+        "--features:; enable features (e.g. html)"
+        "--diagnostic-format:; diagnostics format (human, short)"
+        "--field:; query field"
+        "--one; only one result"
+        "--format:; output format (json, yaml)"
+        "--pretty; pretty-print"
+        "--creation-timestamp:; creation timestamp"
+        ) #<#
+
+        command -f completion//parseoptions -n
+        case $ARGOPT in
+                (-)
+                        command -f completion//completeoptions
+                        ;;
+                (--root|--font-path|--package-path|--package-cache-path)
+                        complete -P "$PREFIX" -S / -T -d
+                        ;;
+                (--format)
+                        complete -P "$PREFIX" json yaml
+                        ;;
+                (--features)
+                        complete -P "$PREFIX" html
+                        ;;
+                (--diagnostic-format)
+                        complete -P "$PREFIX" human short
+                        ;;
+                ('')
+                        complete -P "$PREFIX" -f
+                        ;;
+        esac
+}
+
+# vim: set ft=sh ts=8 sts=8 sw=8 et:

--- a/share/completion/typst-update
+++ b/share/completion/typst-update
@@ -1,0 +1,24 @@
+function completion/typst::update:arg {
+
+        OPTIONS=( #>#
+        "--force; force update"
+        "--revert; revert packages"
+        "--backup-path:; backup path"
+        ) #<#
+
+        command -f completion//parseoptions -n
+        case $ARGOPT in
+                (-)
+                        command -f completion//completeoptions
+                        ;;
+                (--backup-path)
+                        complete -P "$PREFIX" -f
+                        ;;
+                ('')
+                        # no positional args since version defaults to latest
+                        :
+                        ;;
+        esac
+}
+
+# vim: set ft=sh ts=8 sts=8 sw=8 et:

--- a/share/completion/typst-watch
+++ b/share/completion/typst-watch
@@ -1,0 +1,52 @@
+function completion/typst::watch:arg {
+
+        OPTIONS=( #>#
+        "j: --jobs:; number of parallel jobs"
+        "--root:; project root directory"
+        "--input:; additional input"
+        "--font-path:; font search path"
+        "--ignore-system-fonts; ignore system fonts"
+        "--package-path:; package search path"
+        "--package-cache-path:; package cache directory"
+        "--features:; enable features (e.g. html)"
+        "--diagnostic-format:; diagnostics format (human, short)"
+        "f: --format:; output format (pdf, png, svg, html)"
+        "--creation-timestamp:; creation timestamp"
+        "--pages:; pages to export"
+        "--pdf-standard:; PDF standard (1.7, a-2b, a-3b)"
+        "--ppi:; output PPI"
+        "--make-deps:; generate dependency file"
+        "--open; open output after running"
+        "--timings:; print timing info"
+        ) #<#
+
+        command -f completion//parseoptions -n
+        case $ARGOPT in
+                (-)
+                        command -f completion//completeoptions
+                        ;;
+                (--root|--font-path|--package-path|--package-cache-path)
+                        complete -P "$PREFIX" -S / -T -d
+                        ;;
+                (--make-deps|--timings)
+                        complete -P "$PREFIX" -f
+                        ;;
+                (f|--format)
+                        complete -P "$PREFIX" pdf png svg html
+                        ;;
+                (--pdf-standard)
+                        complete -P "$PREFIX" 1.7 a-2b a-3b
+                        ;;
+                (--features)
+                        complete -P "$PREFIX" html
+                        ;;
+                (--diagnostic-format)
+                        complete -P "$PREFIX" human short
+                        ;;
+                ('')
+                        complete -P "$PREFIX" -f
+                        ;;
+        esac
+}
+
+# vim: set ft=sh ts=8 sts=8 sw=8 et:


### PR DESCRIPTION
This adds completion support for [Typst](https://typst.app/).

I'm still getting familiar with Yash's completion syntax, so any feedback on this implementation or style would be appreciated.

One problem i couldnt figure out:
- For the `typst init [args] <TEMPLATE> [DIR]` subcommand ([typst-init](https://github.com/runitclean/yash/blob/trunk/share/completion/typst-init)):
  * `<TEMPLATE>` is a required string (a template name, like: `@preview/charged-ieee`), and shouldn't trigger completion.
  * `[DIR]` is an optional directory, which *should* trigger path completion.
However, I couldn't find a reliable way to distinguish between the two during completion, so both are currently handled with:
  ```sh
  complete -P "$PREFIX" -S / -T -d
  ```
which means that path completion is incorrectly offered for `<TEMPLATE>` as well.

any suggestions on how to better handle this ambiguity would be welcome
