### PR TITLE
add option to disable building documentation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -62,6 +62,7 @@ htmldir = @htmldir@
 
 default_loadpath = @default_loadpath@
 enable_nls = @enable_nls@
+enable_doc = @enable_doc@
 
 all: $(TARGET) share/config tester mofiles docs
 
@@ -119,12 +120,16 @@ mofiles: _PHONY
 	@+(cd po && $(MAKE))
 
 docs:
-	-@+(cd doc && $(MAKE))
+	-@+if $(enable_doc); then (cd doc && $(MAKE)); fi
 man html:
-	-@+(cd doc && $(MAKE) $@-rec)
+	-@+if $(enable_doc); then (cd doc && $(MAKE) $@-rec); fi
 
 INSTALLBINDIRS = $(DESTDIR)$(bindir)
+ifeq ($(enable_doc),true)
 INSTALLDATADIRS = $(DESTDIR)$(yashdatadir) $(DESTDIR)$(yashdatadir)/completion $(DESTDIR)$(yashdatadir)/initialization $(DESTDIR)$(mandir)
+else
+INSTALLDATADIRS = $(DESTDIR)$(yashdatadir) $(DESTDIR)$(yashdatadir)/completion $(DESTDIR)$(yashdatadir)/initialization
+endif
 INSTALLDIRS = $(INSTALLBINDIRS) $(INSTALLDATADIRS) $(DESTDIR)$(htmldir)
 install: install-binary install-data
 install-strip: install-binary-strip install-data
@@ -138,14 +143,14 @@ install-data: share/config installdirs-data-main
 		$(INSTALL_DATA) share/$$file $(DESTDIR)$(yashdatadir)/$$file; \
 	done
 	@+if $(enable_nls); then (cd po && $(MAKE) $@); fi
-	@+(cd doc && $(MAKE) install-rec)
+	@+if $(enable_doc); then (cd doc && $(MAKE) install-rec); fi
 install-html:
-	@+(cd doc && $(MAKE) $@-rec)
+	@+if $(enable_doc); then (cd doc && $(MAKE) $@-rec); fi
 installdirs: installdirs-binary installdirs-data
 installdirs-binary: $(INSTALLBINDIRS)
 installdirs-data: installdirs-data-main
 	@+if $(enable_nls); then (cd po && $(MAKE) $@); fi
-	@+(cd doc && $(MAKE) installdirs-rec)
+	@+if $(enable_doc); then (cd doc && $(MAKE) installdirs-rec); fi
 installdirs-data-main: $(INSTALLDATADIRS)
 installdirs-html: $(DESTDIR)$(htmldir)
 $(INSTALLDIRS):
@@ -163,7 +168,7 @@ uninstall-data:
 	-rmdir $(DESTDIR)$(yashdatadir)/initialization
 	-rmdir $(DESTDIR)$(yashdatadir)
 	@+if $(enable_nls); then (cd po && $(MAKE) $@); fi
-	@+(cd doc && $(MAKE) $@-rec)
+	@+if $(enable_doc); then (cd doc && $(MAKE) $@-rec); fi
 
 DISTDIR = $(TARGET)-$(VERSION)
 DISTS = $(DISTDIR).tar $(DISTDIR).tar.Z $(DISTDIR).tar.gz $(DISTDIR).tar.bz2 $(DISTDIR).tar.xz $(DISTDIR).shar $(DISTDIR).shar.gz $(DISTDIR).zip

--- a/Makefile.in
+++ b/Makefile.in
@@ -125,11 +125,7 @@ man html:
 	-@+if $(enable_doc); then (cd doc && $(MAKE) $@-rec); fi
 
 INSTALLBINDIRS = $(DESTDIR)$(bindir)
-ifeq ($(enable_doc),true)
-INSTALLDATADIRS = $(DESTDIR)$(yashdatadir) $(DESTDIR)$(yashdatadir)/completion $(DESTDIR)$(yashdatadir)/initialization $(DESTDIR)$(mandir)
-else
-INSTALLDATADIRS = $(DESTDIR)$(yashdatadir) $(DESTDIR)$(yashdatadir)/completion $(DESTDIR)$(yashdatadir)/initialization
-endif
+INSTALLDATADIRS = $(DESTDIR)$(yashdatadir) $(DESTDIR)$(yashdatadir)/completion $(DESTDIR)$(yashdatadir)/initialization@doc_mandir@
 INSTALLDIRS = $(INSTALLBINDIRS) $(INSTALLDATADIRS) $(DESTDIR)$(htmldir)
 install: install-binary install-data
 install-strip: install-binary-strip install-data

--- a/configure
+++ b/configure
@@ -46,6 +46,7 @@ enable_array="true"
 enable_dirstack="true"
 enable_double_bracket="true"
 enable_nls="true"
+enable_doc="true"
 enable_help="true"
 enable_history="true"
 enable_lineedit="true"
@@ -164,14 +165,12 @@ do
     esac
 done
 
-# if the user didn't explicitly specify whether they want docs
-# or not, enable them if a2x is found, otherwise disable.
-if [ -z "$enable_doc" ]; then
-    if command -v a2x >/dev/null 2>&1; then
-        enable_doc="true"
-    else
-        printf 'Warning: a2x was not found, documentation will not be built!\n' >&2
-        enable_doc="false"
+# if docs aren't disabled and a2x isn't found, error
+if [ "$enable_doc" = "true" ]; then
+    if ! command -v a2x >/dev/null 2>&1; then
+        printf 'a2x was not found!\n' >&2
+        printf 'you must either install asciidoc or configure with --disable-doc.\n' >&2
+        exit 1
     fi
 fi
 

--- a/configure
+++ b/configure
@@ -1851,6 +1851,13 @@ case "${htmldir}" in
     //) htmldir=/ ;;
 esac
 
+if ${enable_doc}
+then
+    doc_mandir=' $(DESTDIR)$(mandir)'
+else
+    doc_mandir=
+fi
+
 sed_subst_cmd="
 s!@MAKE_INCLUDE@!${MAKE_INCLUDE}!g
 s!@MAKE_SHELL@!${MAKE_SHELL}!g
@@ -1905,18 +1912,8 @@ s!@htmldir@!${htmldir}!g
 s!@default_loadpath@!${default_loadpath}!g
 s!@enable_nls@!${enable_nls}!g
 s!@enable_doc@!${enable_doc}!g
+s!@doc_mandir@!${doc_mandir}!g
 "
-if [ "$enable_doc" = "true" ]; then
-    sed_subst_cmd="
-$sed_subst_cmd
-s!@doc_mandir@! \$\(DESTDIR\)\$\(mandir\)!g
-"
-else
-    sed_subst_cmd="
-$sed_subst_cmd
-s!@doc_mandir@!!g
-"
-fi
 printf '\n\n===== Output variables =====\n%s\n' "${sed_subst_cmd}" >&5
 
 

--- a/configure
+++ b/configure
@@ -103,6 +103,7 @@ parseenable() {
         history)        enable_history=$val ;;
         lineedit)       enable_lineedit=$val ;;
         nls)            enable_nls=$val ;;
+        doc)            enable_doc=$val ;;
         printf)         enable_printf=$val ;;
         socket)         enable_socket=$val ;;
         test)           enable_test=$val ;;
@@ -163,6 +164,17 @@ do
     esac
 done
 
+# if the user didn't explicitly specify whether they want docs
+# or not, enable them if a2x is found, otherwise disable.
+if [ -z "$enable_doc" ]; then
+    if command -v a2x >/dev/null 2>&1; then
+        enable_doc="true"
+    else
+        printf 'Warning: a2x was not found, documentation will not be built!\n' >&2
+        enable_doc="false"
+    fi
+fi
+
 if ${help}
 then
     exec cat <<END
@@ -195,6 +207,7 @@ Optional features:
   --enable-history         enable history
   --enable-lineedit        enable command line editing
   --enable-nls             enable native language support
+  --enable-doc             enable building the documentation
   --enable-printf          enable the echo/printf builtins
   --enable-socket          enable socket redirection by /dev/tcp, /dev/udp
   --enable-test            enable the test builtin
@@ -1901,6 +1914,7 @@ s!@docdir@!${docdir}!g
 s!@htmldir@!${htmldir}!g
 s!@default_loadpath@!${default_loadpath}!g
 s!@enable_nls@!${enable_nls}!g
+s!@enable_doc@!${enable_doc}!g
 "
 printf '\n\n===== Output variables =====\n%s\n' "${sed_subst_cmd}" >&5
 

--- a/configure
+++ b/configure
@@ -1916,6 +1916,17 @@ s!@default_loadpath@!${default_loadpath}!g
 s!@enable_nls@!${enable_nls}!g
 s!@enable_doc@!${enable_doc}!g
 "
+if [ "$enable_doc" = "true" ]; then
+    sed_subst_cmd="
+$sed_subst_cmd
+s!@doc_mandir@! \$\(DESTDIR\)\$\(mandir\)!g
+"
+else
+    sed_subst_cmd="
+$sed_subst_cmd
+s!@doc_mandir@!!g
+"
+fi
 printf '\n\n===== Output variables =====\n%s\n' "${sed_subst_cmd}" >&5
 
 

--- a/configure
+++ b/configure
@@ -165,15 +165,6 @@ do
     esac
 done
 
-# if docs aren't disabled and a2x isn't found, error
-if [ "$enable_doc" = "true" ]; then
-    if ! command -v a2x >/dev/null 2>&1; then
-        printf 'a2x was not found!\n' >&2
-        printf 'you must either install asciidoc or configure with --disable-doc.\n' >&2
-        exit 1
-    fi
-fi
-
 if ${help}
 then
     exec cat <<END


### PR DESCRIPTION
Convenient for users who do not need documentation, or anyone who doesn't want to install a2x.