### PR TITLE
Silence annoying clang warn

### DIFF
--- a/configure
+++ b/configure
@@ -279,7 +279,7 @@ trymake () {
     checkby ${CC-${cc}} ${CFLAGS-${cflags}} ${CADDS-${null}} \
         ${CPPFLAGS-${cppflags}} ${CPPADDS-${null}} \
         ${LDFLAGS-${ldflags}} ${LDADDS-${null}} -o "${tempout}" "${tempsrc}" \
-        "$@" ${LDLIBS-${ldlibs}} ${fnobuiltin}
+        "$@" ${LDLIBS-${ldlibs}} ${fnobuiltin} ${wnoreturntype}
 }
 trycompile () {
     checkby ${CC-${cc}} ${CFLAGS-${cflags}} ${CADDS-${null}} \
@@ -470,6 +470,26 @@ END
     then
         checked "yes"
         fnobuiltin="-fno-builtin"
+    else
+        checked "no"
+    fi
+    cflags=${savecflags}
+fi
+
+# check if the compiler accepts the -Wno-return-type option
+if ! ${debug} && [ x"${CFLAGS+set}" != x"set" ]
+then
+    checking 'whether the compiler accepts -Wno-return-type flag'
+    savecflags=${cflags}
+    cflags="-Wno-return-type"
+    cat >"${tempsrc}" <<END
+int main(void) { return 0; }
+END
+    if
+        trycompile
+    then
+        checked "yes"
+        wnoreturntype="-Wno-return-type"
     else
         checked "no"
     fi


### PR DESCRIPTION
fixes #35

Maybe instead you could replace all uses of `assert(false)` with a macro `UNREACHABLE()` that expands to `assert(false)` in debug builds and `__builtin_unreachable()` in release builds (or nothing if `__GNUC__` isn't defined), that might actually improve performance in some cases since it's explicitly telling the compiler this path should never run instead of just doing nothing.