### PR TITLE
Test cross-compilation in GitHub Actions

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -58,7 +58,7 @@ jobs:
         ./configure --host=aarch64-linux-gnu CADDS="-I/usr/include/aarch64-linux-gnu" LDADDS="-L/usr/lib/aarch64-linux-gnu" || cat config.log
     - name: make for arm64
       run: |
-        cd yash-?*
+        cd yash-?*/
         make -j$(nproc) yash
 
   summarize:

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -42,8 +42,9 @@ jobs:
     - uses: actions/checkout@v5
     - name: install prerequisites
       run: |
+        sudo dpkg --add-architecture arm64
         sudo apt-get update
-        sudo apt-get install asciidoc gettext libncurses-dev gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libc6-dev-arm64-cross
+        sudo apt-get install asciidoc gettext gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libc6-dev-arm64-cross libncurses-dev:arm64
     - name: create distdir
       run: |
         ./configure
@@ -52,7 +53,7 @@ jobs:
     - name: configure for cross compilation to arm64
       run: |
         cd yash-?*/
-        ./configure --host=aarch64-linux-gnu
+        ./configure --host=aarch64-linux-gnu CADDS="-I/usr/include/aarch64-linux-gnu" LDADDS="-L/usr/lib/aarch64-linux-gnu" || cat config.log
     - name: make for arm64
       run: |
         cd yash-?*

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -36,10 +36,11 @@ jobs:
       run: make -j$(sysctl -n hw.logicalcpu) check
 
   check-cross-compile:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v5
+    - run: cat /etc/apt/sources.list
     - name: install prerequisites
       run: |
         sudo dpkg --add-architecture arm64

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-    - name: preparation
+    - name: install prerequisites
       run: |
         sudo apt-get update
         sudo apt-get install asciidoc gettext libncurses-dev
@@ -28,12 +28,34 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-    - name: preparation
+    - name: install prerequisites
       run: brew install asciidoc gettext ncurses
     - name: configure
       run: ./configure CADDS="-I$(brew --prefix gettext)/include" LDADDS="-L$(brew --prefix gettext)/lib"
     - name: make check
       run: make -j$(sysctl -n hw.logicalcpu) check
+
+  check-cross-compile:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v5
+    - name: install prerequisites
+      run: |
+        sudo apt-get update
+        sudo apt-get install asciidoc gettext libncurses-dev gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libc6-dev-arm64-cross
+    - name: create distdir
+      run: |
+        ./configure
+        make distdir
+    - name: configure for cross compilation to arm64
+      run: |
+        cd yash-?*
+        ./configure --host=aarch64-linux-gnu
+    - name: make for arm64
+      run: |
+        cd yash-?*
+        make -j$(nproc) yash
 
   summarize:
     runs-on: ubuntu-latest

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -47,7 +47,8 @@ jobs:
     - name: create distdir
       run: |
         ./configure
-        make distdir
+        make dist-zstd
+        tar -x --zstd -f yash-?*.tar.zst
     - name: configure for cross compilation to arm64
       run: |
         cd yash-?*

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -40,7 +40,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-    - run: cat /etc/apt/sources.list
+    - run: ls /etc/apt/sources.list.d
+    - run: head -n 10000 /etc/apt/sources.list.d/*
     - name: install prerequisites
       run: |
         sudo dpkg --add-architecture arm64

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -51,7 +51,7 @@ jobs:
         tar -x --zstd -f yash-?*.tar.zst
     - name: configure for cross compilation to arm64
       run: |
-        cd yash-?*
+        cd yash-?*/
         ./configure --host=aarch64-linux-gnu
     - name: make for arm64
       run: |

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -40,13 +40,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-    - run: ls /etc/apt/sources.list.d
-    - run: head -n 10000 /etc/apt/sources.list.d/*
+    - name: install cross compilation environment
+      uses: cyberjunk/gha-ubuntu-cross@v5
+      with:
+        arch: arm64
     - name: install prerequisites
       run: |
-        sudo dpkg --add-architecture arm64
-        sudo apt-get update
-        sudo apt-get install asciidoc gettext gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu libc6-dev-arm64-cross libncurses-dev:arm64
+        sudo apt-get install asciidoc gettext libncurses-dev:arm64
     - name: create distdir
       run: |
         ./configure

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -36,7 +36,7 @@ jobs:
       run: make -j$(sysctl -n hw.logicalcpu) check
 
   check-cross-compile:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v5
@@ -61,7 +61,7 @@ jobs:
 
   summarize:
     runs-on: ubuntu-latest
-    needs: [check-on-ubuntu, check-on-macos]
+    needs: [check-on-ubuntu, check-on-macos, check-cross-compile]
     if: ${{ always() }}
     steps:
     - uses: Kesin11/actions-timeline@v2


### PR DESCRIPTION
#203 added cross-compilation support. This PR updates the GitHub Actions workflow to test it.

## Summary by Copilot

This pull request updates the GitHub Actions workflow in `.github/workflows/c.yml` to improve setup clarity and add cross-compilation support. The most significant changes are the renaming of a setup step for clarity and the introduction of a new job for cross-compiling the project to arm64.

Workflow setup improvements:

* Renamed the job step from `preparation` to `install prerequisites` for clearer intent in both Ubuntu and macOS environments.

Cross-compilation support:

* Added a new `check-cross-compile` job that sets up an arm64 cross-compilation environment on Ubuntu, installs necessary dependencies, configures, and builds the project for arm64.
* Updated the `summarize` job to depend on the new `check-cross-compile` job, ensuring results from all build environments are included.