### PR TITLE
Suppress compiler warnings with __builtin_unreachable

### DIFF
--- a/arith.c
+++ b/arith.c
@@ -1,6 +1,6 @@
 /* Yash: yet another shell */
 /* arith.c: arithmetic expansion */
-/* (C) 2007-2022 magicant */
+/* (C) 2007-2025 magicant */
 
 /* This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -318,7 +318,7 @@ wchar_t *value_to_string(const value_T *value)
                 return NULL;
             }
     }
-    assert(false);
+    UNREACHABLE();
 }
 
 /* Applies the binary operation defined by token `ttype' to operands `lhs' and
@@ -354,7 +354,7 @@ bool do_binary_calculation(
                     }
                     break;
                 case VT_VAR:
-                    assert(false);
+                    UNREACHABLE();
                 case VT_INVALID:
                     break;
             }
@@ -384,7 +384,7 @@ bool do_binary_calculation(
             *result = *rhs;
             break;
         default:
-            assert(false);
+            UNREACHABLE();
     }
     return true;
 }
@@ -425,7 +425,7 @@ bool do_long_calculation1(atokentype_T ttype, long v1, long v2, long *result)
             *result = v1 % v2;
             return true;
         default:
-            assert(false);
+            UNREACHABLE();
     }
 
 overflow:
@@ -467,7 +467,7 @@ bool do_long_calculation2(atokentype_T ttype, long v1, long v2, long *result)
             *result = v1 | v2;
             return true;
         default:
-            assert(false);
+            UNREACHABLE();
     }
 
 overflow:
@@ -498,7 +498,7 @@ long do_long_comparison(atokentype_T ttype, long v1, long v2)
         case TT_EXCLEQUAL:
             return v1 != v2;
         default:
-            assert(false);
+            UNREACHABLE();
     }
 }
 
@@ -533,7 +533,7 @@ bool do_double_calculation(
             *result = fmod(v1, v2);
             return true;
         default:
-            assert(false);
+            UNREACHABLE();
     }
 
 #if DOUBLE_DIVISION_BY_ZERO_ERROR
@@ -560,7 +560,7 @@ long do_double_comparison(atokentype_T ttype, double v1, double v2)
         case TT_EXCLEQUAL:
             return v1 != v2;
         default:
-            assert(false);
+            UNREACHABLE();
     }
 }
 
@@ -588,7 +588,7 @@ void parse_conditional(evalinfo_T *info, value_T *result)
             case VT_INVALID:  valid = false, cond = true;   break;
             case VT_LONG:     cond = result2->v_long;       break;
             case VT_DOUBLE:   cond = result2->v_double;     break;
-            default:          assert(false);
+            default:          UNREACHABLE();
         }
 
         bool saveparseonly2 = info->parseonly || !valid;
@@ -628,7 +628,7 @@ void parse_logical_or(evalinfo_T *info, value_T *result)
             case VT_INVALID: valid = false, value = true;  break;
             case VT_LONG:    value = result->v_long;       break;
             case VT_DOUBLE:  value = result->v_double;     break;
-            default:         assert(false);
+            default:         UNREACHABLE();
         }
 
         info->parseonly |= value;
@@ -638,7 +638,7 @@ void parse_logical_or(evalinfo_T *info, value_T *result)
             case VT_INVALID: valid = false;             break;
             case VT_LONG:    value = result->v_long;    break;
             case VT_DOUBLE:  value = result->v_double;  break;
-            default:         assert(false);
+            default:         UNREACHABLE();
         }
         if (valid)
             result->type = VT_LONG, result->v_long = value;
@@ -664,7 +664,7 @@ void parse_logical_and(evalinfo_T *info, value_T *result)
             case VT_INVALID: valid = false, value = false;  break;
             case VT_LONG:    value = result->v_long;        break;
             case VT_DOUBLE:  value = result->v_double;      break;
-            default:         assert(false);
+            default:         UNREACHABLE();
         }
 
         info->parseonly |= !value;
@@ -674,7 +674,7 @@ void parse_logical_and(evalinfo_T *info, value_T *result)
             case VT_INVALID: valid = false;             break;
             case VT_LONG:    value = result->v_long;    break;
             case VT_DOUBLE:  value = result->v_double;  break;
-            default:         assert(false);
+            default:         UNREACHABLE();
         }
         if (valid)
             result->type = VT_LONG, result->v_long = value;
@@ -773,7 +773,7 @@ void parse_equality(evalinfo_T *info, value_T *result)
                         result->type = VT_INVALID;
                         break;
                     case VT_VAR:
-                        assert(false);
+                        UNREACHABLE();
                 }
                 break;
             default:
@@ -815,7 +815,7 @@ void parse_relational(evalinfo_T *info, value_T *result)
                         result->type = VT_INVALID;
                         break;
                     case VT_VAR:
-                        assert(false);
+                        UNREACHABLE();
                 }
                 break;
             default:
@@ -947,7 +947,7 @@ void parse_prefix(evalinfo_T *info, value_T *result)
                     break;
                 case VT_DOUBLE:   result->v_double = -result->v_double;  break;
                 case VT_INVALID:  break;
-                default:          assert(false);
+                default:          UNREACHABLE();
                 }
             }
             break;
@@ -973,7 +973,7 @@ void parse_prefix(evalinfo_T *info, value_T *result)
                 case VT_INVALID:
                     break;
                 default:
-                    assert(false);
+                    UNREACHABLE();
             }
             break;
         default:
@@ -1039,7 +1039,7 @@ bool do_increment_or_decrement(atokentype_T ttype, value_T *value)
                 break;
             case VT_DOUBLE:  value->v_double++;  break;
             case VT_INVALID: break;
-            default:         assert(false);
+            default:         UNREACHABLE();
         }
     } else {
         switch (value->type) {
@@ -1052,7 +1052,7 @@ bool do_increment_or_decrement(atokentype_T ttype, value_T *value)
                 break;
             case VT_DOUBLE:  value->v_double--;  break;
             case VT_INVALID: break;
-            default:         assert(false);
+            default:         UNREACHABLE();
         }
     }
     return true;

--- a/builtin.c
+++ b/builtin.c
@@ -532,7 +532,7 @@ void generate_builtin_candidates(const le_compopt_T *compopt)
             case BI_ELECTIVE:      type = CGT_LBUILTIN;  break;
             case BI_EXTENSION:     type = CGT_XBUILTIN;  break;
             case BI_SUBSTITUTIVE:  type = CGT_UBUILTIN;  break;
-            default:               assert(false);
+            default:               UNREACHABLE();
         }
         if (!(compopt->type & type))
             continue;

--- a/builtins/printf.c
+++ b/builtins/printf.c
@@ -157,7 +157,7 @@ int echo_builtin(int argc, void **argv)
                     case L'n':  nonewline = true;   break;
                     case L'e':  escape    = true;   break;
                     case L'E':  escape    = false;  break;
-                    default:    assert(false);
+                    default:    UNREACHABLE();
                 }
             }
         }
@@ -582,7 +582,7 @@ flag_error:
             break;
         case FT_RAW:
         case FT_ECHO:
-            assert(false);
+            UNREACHABLE();
         default:
             result->value.conv.spec = sb_tostr(&buf);
             result->value.conv.position = position;
@@ -727,7 +727,7 @@ enum printf_result_T printf_printf(
                 arg = L"";
             return printf_print_escape(format, arg, buf);
     }
-    assert(false);
+    UNREACHABLE();
 }
 
 /* Parses the specified string as an integer. */

--- a/builtins/test.c
+++ b/builtins/test.c
@@ -262,7 +262,7 @@ bool test_file(wchar_t type, const char *file) {
             return st.st_mode & S_ISUID;
     }
 
-    assert(false);
+    UNREACHABLE();
 }
 
 /* Tests the specified three-token expression. */
@@ -807,7 +807,7 @@ int eval_dbexp(const dbexp_T *e)
             break;
 
         default:
-            assert(false);
+            UNREACHABLE();
     }
 
     free(lhs);

--- a/common.h
+++ b/common.h
@@ -1,6 +1,6 @@
 /* Yash: yet another shell */
 /* common.h: defines symbols common to all sources. */
-/* (C) 2007-2023 magicant */
+/* (C) 2007-2025 magicant */
 
 /* This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -52,6 +52,16 @@
 # define DUMMY_INIT(dummy_initial_value)
 #else
 # define DUMMY_INIT(dummy_initial_value) = (dummy_initial_value)
+#endif
+
+#if defined(__has_builtin) && __has_builtin(__builtin_unreachable)
+# define UNREACHABLE() \
+    do { \
+        assert(!"unreachable code"); \
+        __builtin_unreachable(); \
+    } while (0)
+#else
+# define UNREACHABLE() assert(!"unreachable code")
 #endif
 
 #define ARGV(i) ((wchar_t *) argv[i])

--- a/exec.c
+++ b/exec.c
@@ -410,7 +410,7 @@ void exec_pipelines_async(const pipeline_T *p)
         /* child process: execute the commands and then exit */
         maybe_redirect_stdin_to_devnull();
         exec_pipelines(p, true);
-        assert(false);
+        UNREACHABLE();
     } else {
         /* fork failure */
         laststatus = Exit_NOEXEC;
@@ -455,7 +455,7 @@ exec_one_command: /* child process */
             if (type == E_ASYNC && pipe.pi_fromprevfd < 0)
                 maybe_redirect_stdin_to_devnull();
             exec_one_command(c, true);
-            assert(false);
+            UNREACHABLE();
         } else if (pid >= 0) {
             /* parent process: fork succeeded */
             if (pgid == 0)
@@ -589,7 +589,7 @@ bool is_err_condition_for(const command_T *c)
             return false;
     }
 
-    assert(false);
+    UNREACHABLE();
 }
 
 /* Updates the contents of the `pipeinfo_T' to proceed to the next process
@@ -969,7 +969,7 @@ void search_command(
                     return;
                 }
             case BI_SPECIAL:
-                assert(false);
+                UNREACHABLE();
             case BI_SUBSTITUTIVE:
                 break;
         }
@@ -1235,7 +1235,7 @@ void exec_nonsimple_command(command_T *c, bool finally_exit)
 {
     switch (c->c_type) {
     case CT_SIMPLE:
-        assert(false);
+        UNREACHABLE();
     case CT_SUBSHELL:
         if (finally_exit) {
             /* This is the last command to execute in the current shell, hence
@@ -1698,7 +1698,7 @@ wchar_t *exec_command_substitution(const embedcmd_T *cmdsub)
             exec_and_or_lists(cmdsub->value.preparsed, true);
         else
             exec_wcs(cmdsub->value.unparsed, gt("command substitution"), true);
-        assert(false);
+        UNREACHABLE();
     }
 }
 

--- a/expand.c
+++ b/expand.c
@@ -865,11 +865,11 @@ treat_array:
                 concat = false;
                 break;
             default:
-                assert(false);
+                UNREACHABLE();
             }
             break;
         default:
-            assert(false);
+            UNREACHABLE();
     }
 
     /* if `PT_COLON' is true, empty string is treated as unset */
@@ -2066,7 +2066,7 @@ bool should_escape(charcategory_T cc, escaping_T escaping)
         case ES_QUOTED:
             return cc & CC_QUOTED;
     }
-    assert(false);
+    UNREACHABLE();
 }
 
 /* Removes all quotation marks in the input string `s' and optionally add

--- a/history.c
+++ b/history.c
@@ -1467,7 +1467,7 @@ int fc_print_entries(
                 r = fprintf(f, "%s\n", e->value);
                 break;
             default:
-                assert(false);
+                UNREACHABLE();
         }
         if (r < 0) {
             xerror(errno, Ngt("cannot print to the standard output"));
@@ -1608,7 +1608,7 @@ error1:
 #ifndef NDEBUG
         free(command);
 #endif
-        assert(false);
+        UNREACHABLE();
     }
 }
 

--- a/input.c
+++ b/input.c
@@ -133,7 +133,7 @@ read_input:  /* if there's nothing in the buffer, read the next input */
                 case W_READY:
                     break;
                 case W_TIMED_OUT:
-                    assert(false);
+                    UNREACHABLE();
                 case W_INTERRUPTED:
                     // Ignore interruption and continue reading, because:
                     //  1) POSIX does not require to handle interruption, and
@@ -325,7 +325,7 @@ struct promptset_T get_prompt(int type)
         case 1:   num = L'1';  break;
         case 2:   num = L'2';  break;
         case 4:   num = L'4';  break;
-        default:  assert(false);
+        default:  UNREACHABLE();
     }
 
     wchar_t *prompt = expand_prompt_variable(num, L'\0');

--- a/job.c
+++ b/job.c
@@ -644,7 +644,7 @@ int calc_status(int status)
         return WTERMSIG(status) + TERMSIGOFFSET;
     if (WIFSTOPPED(status))
         return WSTOPSIG(status) + TERMSIGOFFSET;
-    assert(false);
+    UNREACHABLE();
 }
 
 /* Computes the exit status of the specified process.
@@ -676,7 +676,7 @@ int calc_status_of_job(const job_T *job)
         }
         /* falls thru! */
     default:
-        assert(false);
+        UNREACHABLE();
     }
 }
 
@@ -741,7 +741,7 @@ exitstatus:
             return malloc_printf(gt("Killed (SIG%ls)"), get_signal_name(sig));
         }
     }
-    assert(false);
+    UNREACHABLE();
 }
 
 /* Returns a string that describes the status of the specified job
@@ -759,12 +759,12 @@ char *get_job_status_string(const job_T *job, bool *needfree)
         for (size_t i = job->j_pcount; ; )
             if (job->j_procs[--i].pr_status == JS_STOPPED)
                 return get_process_status_string(&job->j_procs[i], needfree);
-        assert(false);
+        UNREACHABLE();
     case JS_DONE:
         return get_process_status_string(
                 &job->j_procs[job->j_pcount - 1], needfree);
     }
-    assert(false);
+    UNREACHABLE();
 }
 
 /* Returns true iff there is any job whose status has been changed but not yet
@@ -1267,7 +1267,7 @@ int continue_job(size_t jobnumber, job_T *job, bool fg)
                 remove_job(jobnumber);
                 break;
             default:
-                assert(false);
+                UNREACHABLE();
         }
     } else {
         lastasyncpid = job->j_procs[job->j_pcount - 1].pr_pid;

--- a/lineedit/complete.c
+++ b/lineedit/complete.c
@@ -1,6 +1,6 @@
 /* Yash: yet another shell */
 /* complete.c: command line completion */
-/* (C) 2007-2024 magicant */
+/* (C) 2007-2025 magicant */
 
 /* This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1383,7 +1383,7 @@ void quote(xwcsbuf_T *restrict buf,
             }
             return;
     }
-    assert(false);
+    UNREACHABLE();
 }
 
 
@@ -1510,17 +1510,17 @@ int complete_builtin(int argc __attribute__((unused)), void **argv)
                                             cgtype |= CGT_EXTCOMMAND;  break;
                                     }
                                     break;
-                                default:    assert(false);
+                                default:    UNREACHABLE();
                                 }
                                 break;
-                            default:    assert(false);
+                            default:    UNREACHABLE();
                         }
                         break;
                     case L'f':
                         switch (opt->longopt[1]) {
                             case L'i':  cgtype |= CGT_DONE;      break;
                             case L'u':  cgtype |= CGT_FUNCTION;  break;
-                            default:    assert(false);
+                            default:    UNREACHABLE();
                         }
                         break;
                     case L'g':  cgtype |= CGT_GALIAS;  break;
@@ -1537,7 +1537,7 @@ int complete_builtin(int argc __attribute__((unused)), void **argv)
                                 cgtype |= CGT_XBUILTIN | CGT_UBUILTIN;
                                 break;
                             case L'u':  cgtype |= CGT_RUNNING;   break;
-                            default:    assert(false);
+                            default:    UNREACHABLE();
                         }
                         break;
                     case L's':
@@ -1550,11 +1550,11 @@ int complete_builtin(int argc __attribute__((unused)), void **argv)
                             case L'p':  cgtype |= CGT_SBUILTIN;  break;
                             case L't':  cgtype |= CGT_STOPPED;   break;
                             case L'u':  cgtype |= CGT_UBUILTIN;  break;
-                            default:    assert(false);
+                            default:    UNREACHABLE();
                         }
                         break;
                     default:
-                        assert(false);
+                        UNREACHABLE();
                 }
                 break;
 dupopterror:

--- a/lineedit/compparse.c
+++ b/lineedit/compparse.c
@@ -1,6 +1,6 @@
 /* Yash: yet another shell */
 /* compparse.c: simple parser for command line completion */
-/* (C) 2007-2024 magicant */
+/* (C) 2007-2025 magicant */
 
 /* This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1029,7 +1029,7 @@ check_closing_paren:
             break;
         case PT_ASSIGN:
         case PT_ERROR:
-            assert(false);
+            UNREACHABLE();
         default:
             if (pe->pe_type & PT_NEST)
                 break;

--- a/lineedit/display.c
+++ b/lineedit/display.c
@@ -1,6 +1,6 @@
 /* Yash: yet another shell */
 /* display.c: display control */
-/* (C) 2007-2012 magicant */
+/* (C) 2007-2025 magicant */
 
 /* This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -832,19 +832,19 @@ void print_search(void)
     switch (le_search_type) {
         const char *text;
         case SEARCH_PREFIX:
-            assert(false);
+            UNREACHABLE();
         case SEARCH_VI:
             switch (le_search_direction) {
                 case FORWARD:   lebuf_putwchar(L'?', false);  break;
                 case BACKWARD:  lebuf_putwchar(L'/', false);  break;
-                default:        assert(false);
+                default:        UNREACHABLE();
             }
             break;
         case SEARCH_EMACS:
             switch (le_search_direction) {
                 case FORWARD:   text = "Forward search: ";   break;
                 case BACKWARD:  text = "Backward search: ";  break;
-                default:        assert(false);
+                default:        UNREACHABLE();
             }
             lebuf_wprintf(false, L"%s", gt(text));
             break;

--- a/lineedit/editing.c
+++ b/lineedit/editing.c
@@ -1,6 +1,6 @@
 /* Yash: yet another shell */
 /* editing.c: main editing module */
-/* (C) 2007-2023 magicant */
+/* (C) 2007-2025 magicant */
 
 /* This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -349,7 +349,7 @@ void le_editing_init(void)
     switch (shopt_lineedit) {
         case SHOPT_VI:     le_set_mode(LE_MODE_VI_INSERT);  break;
         case SHOPT_EMACS:  le_set_mode(LE_MODE_EMACS);      break;
-        default:           assert(false);
+        default:           UNREACHABLE();
     }
 
     last_command.func = 0;
@@ -766,7 +766,7 @@ void set_search_mode(le_mode_id_T mode, enum le_search_direction_T dir,
     switch (mode) {
         case LE_MODE_VI_SEARCH:     le_search_type = SEARCH_VI;     break;
         case LE_MODE_EMACS_SEARCH:  le_search_type = SEARCH_EMACS;  break;
-        default:                    assert(false);
+        default:                    UNREACHABLE();
     }
 
     wb_init(&le_search_buffer);
@@ -2980,7 +2980,7 @@ end:
 #ifndef NDEBUG
         free(command);
 #endif
-        assert(false);
+        UNREACHABLE();
     }
 }
 
@@ -3586,7 +3586,7 @@ void cmd_srch_backward_delete_char(wchar_t c __attribute__((unused)))
                 cmd_alert(L'\0');
                 return;
             case SEARCH_PREFIX:
-                assert(false);
+                UNREACHABLE();
         }
     }
 
@@ -3680,7 +3680,7 @@ bool need_update_last_search_value(void)
         case SEARCH_EMACS:
             return le_search_buffer.contents[0] != L'\0';
     }
-    assert(false);
+    UNREACHABLE();
 }
 
 /* Aborts the history search.
@@ -3760,7 +3760,7 @@ void perform_search(const wchar_t *pattern,
             break;
         }
         default:
-            assert(false);
+            UNREACHABLE();
     }
     if (xfnm == NULL) {
         l = Histlist;

--- a/lineedit/keymap.c
+++ b/lineedit/keymap.c
@@ -1,6 +1,6 @@
 /* Yash: yet another shell */
 /* keymap.c: mappings from keys to functions */
-/* (C) 2007-2023 magicant */
+/* (C) 2007-2025 magicant */
 
 /* This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -545,7 +545,7 @@ int print_binding_main(
         case LE_MODE_EMACS:         modechar = 'e';  break;
         case LE_MODE_EMACS_SEARCH:  modechar = 'E';  break;
         case LE_MODE_CHAR_EXPECT:   modechar = 'c';  break;
-        default:                    assert(false);
+        default:                    UNREACHABLE();
     }
     if (keyseq[0] == L'-')
         format = "bindkey -%c -- %ls %s\n";

--- a/lineedit/lineedit.c
+++ b/lineedit/lineedit.c
@@ -1,6 +1,6 @@
 /* Yash: yet another shell */
 /* lineedit.c: command line editing */
-/* (C) 2007-2016 magicant */
+/* (C) 2007-2025 magicant */
 
 /* This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -103,9 +103,9 @@ inputresult_T le_readline(
             free(resultline);
             return INPUT_INTERRUPTED;
         case LE_EDITSTATE_EDITING:
-            assert(false);
+            UNREACHABLE();
     }
-    assert(false);
+    UNREACHABLE();
 }
 
 /* Clears the edit line and restores the terminal state.
@@ -224,7 +224,7 @@ void read_next(void)
                             return;
                     }
                 default:
-                    assert(false);
+                    UNREACHABLE();
             }
             if (has_meta_bit(c)) {
                 sb_ccat(&reader_first_buffer, ESCAPE_CHAR);

--- a/option.c
+++ b/option.c
@@ -621,7 +621,7 @@ int handle_search_result(plist_T *options, void *const *argv, bool enable,
                                 }
                                 break;
                             default:
-                                assert(false);
+                                UNREACHABLE();
                         }
                     } else {
                         optarg = &eq[1];
@@ -752,7 +752,7 @@ int set_normal_option(const struct xgetopt_T *opt, const wchar_t *arg,
                 return print_builtin_help(L"set");
 #endif
             default:
-                assert(false);
+                UNREACHABLE();
         }
     } else {
         switch (index) {
@@ -779,7 +779,7 @@ int set_normal_option(const struct xgetopt_T *opt, const wchar_t *arg,
                 shell_invocation->rcfile = arg;
                 break;
             case NOI_N:
-                assert(false);
+                UNREACHABLE();
         }
     }
     return Exit_SUCCESS;

--- a/parser.c
+++ b/parser.c
@@ -806,7 +806,7 @@ parseresult_T read_and_parse(parseparam_T *info, and_or_T **restrict resultp)
             andorsfree(r);
             return PR_INPUT_ERROR;
     }
-    assert(false);
+    UNREACHABLE();
 }
 
 /* Parses a string recognizing parameter expansions, command substitutions of
@@ -922,7 +922,7 @@ const char *get_errmsg_unexpected_tokentype(tokentype_T tokentype)
             return Ngt("encountered `%ls' "
                         "without a matching `if' and/or `then'");
         default:
-            assert(false);
+            UNREACHABLE();
     }
 }
 
@@ -1331,7 +1331,7 @@ wordunit_T *parse_special_word_unit(parsestate_T *ps, bool indq)
     case L'`':
         return parse_cmdsubst_in_backquote(ps, indq);
     default:
-        assert(false);
+        UNREACHABLE();
     }
 }
 
@@ -2355,7 +2355,7 @@ redir_T *tryparse_redirect(parsestate_T *ps)
             result->rd_type = RT_HERESTR;
             break;
         default:
-            assert(false);
+            UNREACHABLE();
     }
 
     /* parse redirection target file token */
@@ -2509,7 +2509,7 @@ command_T *parse_group(parsestate_T *ps)
             starts = L"(", ends = L")";
             break;
         default:
-            assert(false);
+            UNREACHABLE();
     }
     next_token(ps);
 
@@ -2666,7 +2666,7 @@ command_T *parse_while(parsestate_T *ps)
     switch (ps->tokentype) {
         case TT_WHILE:  whltype = true;   break;
         case TT_UNTIL:  whltype = false;  break;
-        default:        assert(false);
+        default:        UNREACHABLE();
     }
     next_token(ps);
 
@@ -3369,7 +3369,7 @@ void reject_pending_heredocs(parsestate_T *ps)
         switch (r->rd_type) {
             case RT_HERE:    operator = "<<";   break;
             case RT_HERERT:  operator = "<<-";  break;
-            default:         assert(false);
+            default:         UNREACHABLE();
         }
         serror(ps, Ngt("here-document content for %s%ls is missing"),
                 operator, r->rd_hereend);
@@ -3842,7 +3842,7 @@ const wchar_t *case_item_terminator(casecont_T cc)
         case CC_FALLTHRU:  return L";&";
         case CC_CONTINUE:  return L";|";
     }
-    assert(false);
+    UNREACHABLE();
 }
 
 #if YASH_ENABLE_DOUBLE_BRACKET
@@ -3966,7 +3966,7 @@ void print_redirections(
             case RT_HERESTR:  s = L"<<<";  type = file;  break;
             case RT_PROCIN:   s = L"<(";   type = proc;  break;
             case RT_PROCOUT:  s = L">(";   type = proc;  break;
-            default: assert(false);
+            default: UNREACHABLE();
         }
         wb_wprintf(&pr->buffer, L"%d%ls", rd->rd_fd, s);
         switch (type) {

--- a/path.c
+++ b/path.c
@@ -1891,7 +1891,7 @@ perm_end:
             case L'+':  newmask |= who & perm;                      break;
             case L'-':  newmask &= ~(who & perm);                   break;
             case L'=':  newmask = (~who & newmask) | (who & perm);  break;
-            default:    assert(false);
+            default:    UNREACHABLE();
         }
 
         switch (*maskstr) {

--- a/redir.c
+++ b/redir.c
@@ -406,7 +406,7 @@ openwithflags:
                 return false;
             break;
         default:
-            assert(false);
+            UNREACHABLE();
         }
 
         /* move the new FD to `r->rd_fd' */
@@ -871,7 +871,7 @@ int open_process_redirection(const embedcmd_T *command, redirtype_T type)
             exec_and_or_lists(command->value.preparsed, true);
         else
             exec_wcs(command->value.unparsed, gt("process redirection"), true);
-        assert(false);
+        UNREACHABLE();
     }
 }
 

--- a/variable.c
+++ b/variable.c
@@ -446,7 +446,7 @@ char *get_exported_value(const wchar_t *name)
                 case VF_ARRAY:
                     return realloc_wcstombs(joinwcsarray(var->v_vals, L":"));
                 default:
-                    assert(false);
+                    UNREACHABLE();
             }
         }
     }
@@ -601,7 +601,7 @@ variable_T *new_variable(const wchar_t *name, scope_T scope)
         case SCOPE_GLOBAL:  var = new_global(name);     break;
         case SCOPE_LOCAL:   var = new_local(name);      break;
         case SCOPE_TEMP:    var = new_temporary(name);  break;
-        default:            assert(false);
+        default:            UNREACHABLE();
     }
     if (var->v_type & VF_READONLY) {
         xerror(0, Ngt("$%ls is read-only"), name);
@@ -1698,7 +1698,7 @@ int typeset_builtin(int argc, void **argv)
             assert(wcscmp(ARGV(0), L"typeset") == 0);
             break;
         default:
-            assert(false);
+            UNREACHABLE();
     }
 
     if (function && global && ARGV(0)[0] == L't' /*typeset*/)
@@ -1874,7 +1874,7 @@ typeset:
             free(opts);
             break;
         default:
-            assert(false);
+            UNREACHABLE();
     }
     free(quotedvalue);
 }
@@ -1929,7 +1929,7 @@ typeset:;
             free(opts);
             break;
         default:
-            assert(false);
+            UNREACHABLE();
     }
 }
 
@@ -1968,7 +1968,7 @@ void print_function(
                 xprintf("%ls -fr %s%ls\n", argv0, separator, name);
             break;
         default:
-            assert(false);
+            UNREACHABLE();
     }
 
 end:
@@ -2083,7 +2083,7 @@ int array_builtin(int argc, void **argv)
         case DELETE:  min = 1;  max = SIZE_MAX;  break;
         case INSERT:  min = 2;  max = SIZE_MAX;  break;
         case SET:     min = 3;  max = 3;         break;
-        default:      assert(false);
+        default:      UNREACHABLE();
     }
     if (!validate_operand_count(argc - xoptind, min, max))
         return Exit_ERROR;
@@ -2118,7 +2118,7 @@ int array_builtin(int argc, void **argv)
                         name, array, ARGV(xoptind), ARGV(xoptind + 1));
                 break;
             default:
-                assert(false);
+                UNREACHABLE();
         }
     }
     return (yash_error_message_count == 0) ? Exit_SUCCESS : Exit_FAILURE;

--- a/xgetopt.c
+++ b/xgetopt.c
@@ -1,6 +1,6 @@
 /* Yash: yet another shell */
 /* xgetopt.c: command option parser */
-/* (C) 2012-2013 magicant */
+/* (C) 2012-2025 magicant */
 
 /* This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -305,9 +305,9 @@ struct xgetopt_T *found_long_option(const wchar_t *eq,
             /* the argument is split from the option like "--option argument" */
             return parse_separate_option_argument(false, opt);
         case OPTARG_NONE:
-            assert(false);
+            UNREACHABLE();
     }
-    assert(false);
+    UNREACHABLE();
 }
 
 /* This function is called when an option was parsed in an argument string and

--- a/yash.c
+++ b/yash.c
@@ -251,7 +251,7 @@ int main(int argc, char **argv)
         exec_input(input.fd, inputname, XIO_SUBST_ALIAS | XIO_FINALLY_EXIT |
                 (is_interactive ? XIO_INTERACTIVE : 0));
 
-    assert(false);
+    UNREACHABLE();
 }
 
 struct input_file_info_T *new_input_file_info(int fd, size_t bufsize)
@@ -743,7 +743,7 @@ int exit_builtin(int argc, void **argv)
         status = -1;
     }
     exit_shell_with_status(status);
-    assert(false);
+    UNREACHABLE();
 }
 
 #if YASH_ENABLE_HELP


### PR DESCRIPTION
Implements the idea suggested in #208.

## Summary by Copilot

This pull request replaces all instances of the `assert(false)` pattern with a new `UNREACHABLE()` macro throughout the codebase. The `UNREACHABLE()` macro provides a clearer indication of unreachable code and, when supported, uses compiler intrinsics to mark such code paths as unreachable, potentially aiding optimization and diagnostics. The macro is defined in `common.h` and is now used in place of `assert(false)` in various source files.

**Macro introduction and usage update:**

* Added the `UNREACHABLE()` macro in `common.h`, which asserts and uses `__builtin_unreachable()` when available, otherwise just asserts.
* Replaced all instances of `assert(false)` with `UNREACHABLE()` in logic branches that should never be reached, across multiple files including `arith.c`, `builtin.c`, `builtins/printf.c`, `builtins/test.c`, `exec.c`, `expand.c`, and `history.c`. [[1]](diffhunk://#diff-38cb0583603d3b310dd6571888b1f07bb8e1505350371f1eea2b6980a9cec764L321-R321) [[2]](diffhunk://#diff-38cb0583603d3b310dd6571888b1f07bb8e1505350371f1eea2b6980a9cec764L357-R357) [[3]](diffhunk://#diff-38cb0583603d3b310dd6571888b1f07bb8e1505350371f1eea2b6980a9cec764L387-R387) [[4]](diffhunk://#diff-38cb0583603d3b310dd6571888b1f07bb8e1505350371f1eea2b6980a9cec764L428-R428) [[5]](diffhunk://#diff-38cb0583603d3b310dd6571888b1f07bb8e1505350371f1eea2b6980a9cec764L470-R470) [[6]](diffhunk://#diff-38cb0583603d3b310dd6571888b1f07bb8e1505350371f1eea2b6980a9cec764L501-R501) [[7]](diffhunk://#diff-38cb0583603d3b310dd6571888b1f07bb8e1505350371f1eea2b6980a9cec764L536-R536) [[8]](diffhunk://#diff-38cb0583603d3b310dd6571888b1f07bb8e1505350371f1eea2b6980a9cec764L563-R563) [[9]](diffhunk://#diff-38cb0583603d3b310dd6571888b1f07bb8e1505350371f1eea2b6980a9cec764L591-R591) [[10]](diffhunk://#diff-38cb0583603d3b310dd6571888b1f07bb8e1505350371f1eea2b6980a9cec764L631-R631) [[11]](diffhunk://#diff-38cb0583603d3b310dd6571888b1f07bb8e1505350371f1eea2b6980a9cec764L641-R641) [[12]](diffhunk://#diff-38cb0583603d3b310dd6571888b1f07bb8e1505350371f1eea2b6980a9cec764L667-R667) [[13]](diffhunk://#diff-38cb0583603d3b310dd6571888b1f07bb8e1505350371f1eea2b6980a9cec764L677-R677) [[14]](diffhunk://#diff-38cb0583603d3b310dd6571888b1f07bb8e1505350371f1eea2b6980a9cec764L776-R776) [[15]](diffhunk://#diff-38cb0583603d3b310dd6571888b1f07bb8e1505350371f1eea2b6980a9cec764L818-R818) [[16]](diffhunk://#diff-38cb0583603d3b310dd6571888b1f07bb8e1505350371f1eea2b6980a9cec764L950-R950) [[17]](diffhunk://#diff-38cb0583603d3b310dd6571888b1f07bb8e1505350371f1eea2b6980a9cec764L976-R976) [[18]](diffhunk://#diff-38cb0583603d3b310dd6571888b1f07bb8e1505350371f1eea2b6980a9cec764L1042-R1042) [[19]](diffhunk://#diff-38cb0583603d3b310dd6571888b1f07bb8e1505350371f1eea2b6980a9cec764L1055-R1055) [[20]](diffhunk://#diff-a08ccc359ce41eb52461efbfeaaa20c5c4a1b169aa042183491c2bc34d8b8411L535-R535) [[21]](diffhunk://#diff-d75217c6cef851b73563768294572fc2da169aefbcbb31aff5bc52cbbeba5577L160-R160) [[22]](diffhunk://#diff-d75217c6cef851b73563768294572fc2da169aefbcbb31aff5bc52cbbeba5577L585-R585) [[23]](diffhunk://#diff-d75217c6cef851b73563768294572fc2da169aefbcbb31aff5bc52cbbeba5577L730-R730) [[24]](diffhunk://#diff-af628874c6012bc557c8478762adb6b2e737a80ec679c28e9f7c04697e0588f0L265-R265) [[25]](diffhunk://#diff-af628874c6012bc557c8478762adb6b2e737a80ec679c28e9f7c04697e0588f0L810-R810) [[26]](diffhunk://#diff-af29a68f10f30da45d2288eb96a29ce4727d7e3af2834b541b90d5adf5d1235aL413-R413) [[27]](diffhunk://#diff-af29a68f10f30da45d2288eb96a29ce4727d7e3af2834b541b90d5adf5d1235aL458-R458) [[28]](diffhunk://#diff-af29a68f10f30da45d2288eb96a29ce4727d7e3af2834b541b90d5adf5d1235aL592-R592) [[29]](diffhunk://#diff-af29a68f10f30da45d2288eb96a29ce4727d7e3af2834b541b90d5adf5d1235aL972-R972) [[30]](diffhunk://#diff-af29a68f10f30da45d2288eb96a29ce4727d7e3af2834b541b90d5adf5d1235aL1238-R1238) [[31]](diffhunk://#diff-af29a68f10f30da45d2288eb96a29ce4727d7e3af2834b541b90d5adf5d1235aL1701-R1701) [[32]](diffhunk://#diff-4e9f03b0fcb26abe26e8d83441df7ea667ec7e16089a316713421ec74247dce7L868-R872) [[33]](diffhunk://#diff-4e9f03b0fcb26abe26e8d83441df7ea667ec7e16089a316713421ec74247dce7L2069-R2069) [[34]](diffhunk://#diff-54031e44a8100d2dc23bd0d999a41a89d2107a39cfc8232f1b1e6206fbb10086L1470-R1470) [[35]](diffhunk://#diff-54031e44a8100d2dc23bd0d999a41a89d2107a39cfc8232f1b1e6206fbb10086L1611-R1611)

**Copyright update:**

* Updated copyright years in `arith.c` and `common.h` to 2025. [[1]](diffhunk://#diff-38cb0583603d3b310dd6571888b1f07bb8e1505350371f1eea2b6980a9cec764L3-R3) [[2]](diffhunk://#diff-2d8f7f560f562ca6d6ca73d727ef9308082c7adcb8308f997f03c101f6e04bc3L3-R3)

This change improves code clarity and maintainability by standardizing unreachable code handling and leveraging compiler features where available.