### PR TITLE
Check color support using COLORTERM

### DIFF
--- a/share/initialization/common
+++ b/share/initialization/common
@@ -115,7 +115,8 @@ case $- in (*m*)
 esac
 
 # if the terminal supports color...
-if [ "$(tput colors 2>/dev/null || echo 0)" -ge 8 ]; then
+if [ $COLORTERM = "truecolor" ] || [ $COLORTERM = "24bit" ] || \
+  [ "$(tput colors 2>/dev/null || echo 0)" -ge 8 ]; then
 
   # make command output colorful
   if ls --color=auto -d / >/dev/null 2>&1; then

--- a/share/initialization/common
+++ b/share/initialization/common
@@ -115,7 +115,7 @@ case $- in (*m*)
 esac
 
 # if the terminal supports color...
-if [ $COLORTERM = "truecolor" ] || [ $COLORTERM = "24bit" ] || \
+if [ "${COLORTERM-}" = "truecolor" ] || [ "${COLORTERM-}" = "24bit" ] || \
   [ "$(tput colors 2>/dev/null || echo 0)" -ge 8 ]; then
 
   # make command output colorful


### PR DESCRIPTION
Many terminals set COLORTERM to advertise color support so it would be logical to check if this variable is defined before falling back to checking using tput.

Suggested-by: @hyperupcall