### PR TITLE
Add a missing `else` in `fork_and_wait()`

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -1525,7 +1525,7 @@ fork_and_wait_T fork_and_wait(sigtype_T sigtype)
         /* Fork failed. */
         laststatus = Exit_NOEXEC;
         result.namep = NULL;
-    } if (result.cpid > 0) {
+    } else if (result.cpid > 0) {
         /* parent process */
         result.namep = wait_for_child(
                 result.cpid,

--- a/path.c
+++ b/path.c
@@ -1235,8 +1235,8 @@ int change_directory(
     assert(!logical || !ensure_pwd);
 
     if (newpwd[0] == L'\0') {
-	xerror(0, Ngt("empty directory name"));
-	return 5;
+        xerror(0, Ngt("empty directory name"));
+        return 5;
     }
 
     /* get the current value of $PWD as `origpwd' */
@@ -1272,7 +1272,7 @@ int change_directory(
     assert(origpwd == NULL || origpwd[0] == L'/');
 
     wb_init(&curpath);
-    
+
     /* step 3 */
     if (newpwd[0] == L'/') {
         wb_cat(&curpath, newpwd);


### PR DESCRIPTION
Fix an accidental omission of `else` in an `else if` in the fork result branching in `fork_and_wait()`.

Also, fix the only place in the codebase (in `change_directory()`) where tabs are (accidentally) used for indentation.