### PR TITLE
Add completion for 'mount', 'sv', 'aria2c', 'mkinitcpio', '7z', 'hdparm'

### DIFF
--- a/share/completion/7z
+++ b/share/completion/7z
@@ -1,0 +1,79 @@
+# Completion script for the "7z" command.
+
+function completion/7z {
+
+        typeset OPTIONS ARGOPT PREFIX
+        OPTIONS=( #>#
+        "--help"
+        ) #<#
+
+        # first argument is the command
+        if [ ${WORDS[#]} -le 1 ]; then
+                complete -D "add files to archive" -- a
+                complete -D "benchmark" -- b
+                complete -D "delete files from archive" -- d
+                complete -D "extract files (without directory names)" -- e
+                complete -D "calculate hash values for files" -- h
+                complete -D "show information about supported formats" -- i
+                complete -D "list contents of archive" -- l
+                complete -D "rename files in archive" -- rn
+                complete -D "test integrity of archive" -- t
+                complete -D "update files to archive" -- u
+                complete -D "extract files with full paths" -- x
+                return
+        fi
+
+        case $TARGETWORD in
+        (-ao*)
+                complete -T -P "${TARGETWORD%"${TARGETWORD#-ao}"}" -- a s t u
+                return
+                ;;
+        (-t*)
+                typeset mode
+                case ${WORDS[2]} in
+                (a|d|rn|u) mode=w ;;
+                (*)         mode=r ;;
+                esac
+                if [ "$mode" = w ]; then
+                        complete -T -P "${TARGETWORD%"${TARGETWORD#-t}"}" -- \
+                                7z bzip2 gzip swfc tar wim xz zip
+                else
+                        complete -T -P "${TARGETWORD%"${TARGETWORD#-t}"}" -- \
+                                7z apm arj bzip2 cab chm cpio cramfs deb dmg \
+                                elf fat flv gzip hfs iso lzh lzma lzma86 \
+                                macho mbr mslz mub nsis ntfs pe ppmd rar rpm \
+                                squashfs swf swfc tar udf vhd wim xar xz z zip
+                fi
+                return
+                ;;
+        (-mx=*)
+                complete -T -P "${TARGETWORD%"${TARGETWORD#-mx=}"}" -- 0 1 3 5 7 9
+                return
+                ;;
+        (-scs*)
+                complete -T -P "${TARGETWORD%"${TARGETWORD#-scs}"}" -- UTF-8 WIN DOS
+                return
+                ;;
+        (-o*|-w*)
+                complete -P "${TARGETWORD%"${TARGETWORD#-?}"}" -S / -T -d
+                return
+                ;;
+        (-*)
+                complete -- \
+                        -ai -an -ao -ax -bb -bd -bs -bt \
+                        -i -mmf -mhc -mhe -mmt -ms -mx \
+                        -o -p -r -sa -scc -scs -scrc \
+                        -sdel -seml -sfx -si -slp -slt \
+                        -snh -snl -sni -sns -so -spd -spe \
+                        -spf -ssc -sse -ssp -ssw -stl -stm \
+                        -stx -t -u -v -w -x -y
+                return
+                ;;
+        esac
+
+        # by default we just need to complete files
+        complete -f
+}
+
+
+# vim: set ft=sh ts=8 sts=8 sw=8 et:

--- a/share/completion/aria2c
+++ b/share/completion/aria2c
@@ -1,0 +1,262 @@
+# Completion script for the "aria2c" command.
+
+function completion/aria2c {
+
+        typeset OPTIONS ARGOPT PREFIX
+        OPTIONS=( #>#
+        "d: --dir:; directory to store downloaded files"
+        "i: --input-file:; download URIs listed in file"
+        "l: --log:; log file name"
+        "j: --max-concurrent-downloads:; max parallel downloads"
+        "V --check-integrity; check file integrity"
+        "c --continue; continue downloading a partial file"
+        "h --help; show help"
+        "x: --max-connection-per-server:; max connections to one server"
+        "m: --max-tries:; set number of tries"
+        "k: --min-split-size:; min split size"
+        "n --no-netrc; disable netrc support"
+        "o: --out:; output file name"
+        "R --remote-time; retrieve timestamp of remote file"
+        "s: --split:; download using N connections"
+        "t: --timeout:; set timeout in seconds"
+        "U: --user-agent:; set user agent"
+        "p --ftp-pasv; use passive mode in FTP"
+        "S --show-files; print file listing and exit"
+        "O: --index-out:; set file path for file with index"
+        "u: --max-upload-limit:; max upload speed per torrent"
+        "--all-proxy:; proxy server for all protocols"
+        "--all-proxy-passwd:; password for all-proxy"
+        "--all-proxy-user:; user for all-proxy"
+        "--allow-overwrite; allow overwriting existing files"
+        "--allow-piece-length-change; allow piece length change"
+        "--async-dns; enable async DNS"
+        "--auto-file-renaming; auto rename files"
+        "--auto-save-interval:; auto save interval"
+        "--bt-detach-seed-only; exclude seed only downloads from count"
+        "--bt-enable-hook-after-hash-check; allow hook after hash check"
+        "--bt-enable-lpd; enable Local Peer Discovery"
+        "--bt-exclude-tracker:; exclude BitTorrent trackers"
+        "--bt-external-ip:; external IP for BitTorrent"
+        "--bt-force-encryption; require encrypted BitTorrent"
+        "--bt-hash-check-seed; continue to seed after hash check"
+        "--bt-load-saved-metadata; load saved torrent metadata"
+        "--bt-lpd-interface:; interface for Local Peer Discovery"
+        "--bt-max-open-files:; max open files for BitTorrent"
+        "--bt-max-peers:; max peers per torrent"
+        "--bt-metadata-only; download metadata only"
+        "--bt-min-crypto-level:; min encryption level"
+        "--bt-prioritize-piece:; prioritize first and last pieces"
+        "--bt-remove-unselected-file; remove unselected files"
+        "--bt-request-peer-speed-limit:; peer speed limit"
+        "--bt-require-crypto; require crypto handshake"
+        "--bt-save-metadata; save metadata as .torrent"
+        "--bt-seed-unverified; seed without verifying"
+        "--bt-stop-timeout:; stop if speed is 0 for N seconds"
+        "--bt-tracker:; additional BitTorrent trackers"
+        "--bt-tracker-connect-timeout:; tracker connect timeout"
+        "--bt-tracker-interval:; tracker request interval"
+        "--bt-tracker-timeout:; tracker timeout"
+        "--ca-certificate:; CA certificate file"
+        "--certificate:; client certificate file"
+        "--check-certificate; verify peer certificate"
+        "--checksum:; set checksum for file"
+        "--conditional-get; conditional GET"
+        "--conf-path:; config file path"
+        "--connect-timeout:; connect timeout in seconds"
+        "--console-log-level:; console log level"
+        "--content-disposition-default-utf8; default UTF-8 for content disposition"
+        "--daemon; run as daemon"
+        "--deferred-input; deferred input"
+        "--dht-entry-point:; IPv4 DHT entry point"
+        "--dht-entry-point6:; IPv6 DHT entry point"
+        "--dht-file-path:; IPv4 DHT routing table file"
+        "--dht-file-path6:; IPv6 DHT routing table file"
+        "--dht-listen-addr6:; address for IPv6 DHT"
+        "--dht-listen-port:; UDP port for DHT"
+        "--dht-message-timeout:; DHT message timeout"
+        "--disable-ipv6; disable IPv6"
+        "--disk-cache:; disk cache size"
+        "--download-result:; download result format"
+        "--dry-run; check availability without downloading"
+        "--dscp:; DSCP value"
+        "--enable-async-dns6; enable async DNS for IPv6"
+        "--enable-color; enable color output"
+        "--enable-dht; enable IPv4 DHT"
+        "--enable-dht6; enable IPv6 DHT"
+        "--enable-http-keep-alive; enable HTTP keep-alive"
+        "--enable-http-pipelining; enable HTTP pipelining"
+        "--enable-mmap; enable mmap"
+        "--enable-peer-exchange; enable Peer Exchange"
+        "--enable-rpc; enable RPC server"
+        "--event-poll:; event polling method"
+        "--file-allocation:; file allocation method"
+        "--follow-metalink:; follow metalink files"
+        "--follow-torrent:; follow torrent files"
+        "--force-save; force saving"
+        "--force-sequential; force sequential download"
+        "--ftp-passwd:; FTP password"
+        "--ftp-proxy:; proxy server for FTP"
+        "--ftp-proxy-passwd:; password for ftp-proxy"
+        "--ftp-proxy-user:; user for ftp-proxy"
+        "--ftp-reuse-connection; reuse FTP connection"
+        "--ftp-type:; FTP transfer type"
+        "--ftp-user:; FTP user"
+        "--gid:; manually set GID"
+        "--hash-check-only; hash check only without downloading"
+        "--header:; append HTTP request header"
+        "--http-accept-gzip; accept gzip encoding"
+        "--http-auth-challenge; send auth only when requested"
+        "--http-no-cache; send no-cache headers"
+        "--http-passwd:; HTTP password"
+        "--http-proxy:; proxy server for HTTP"
+        "--http-proxy-passwd:; password for http-proxy"
+        "--http-proxy-user:; user for http-proxy"
+        "--http-user:; HTTP user"
+        "--https-proxy:; proxy server for HTTPS"
+        "--https-proxy-passwd:; password for https-proxy"
+        "--https-proxy-user:; user for https-proxy"
+        "--human-readable; human readable output"
+        "--interface:; bind to specified interface"
+        "--listen-port:; TCP port for BitTorrent"
+        "--load-cookies:; load cookies from file"
+        "--log-level:; log level"
+        "--lowest-speed-limit:; close if speed is below limit"
+        "--max-download-limit:; max download speed"
+        "--max-download-result:; max download results"
+        "--max-file-not-found:; max file-not-found retries"
+        "--max-mmap-limit:; max mmap limit"
+        "--max-overall-download-limit:; max overall download speed"
+        "--max-overall-upload-limit:; max overall upload speed"
+        "--max-resume-failure-tries:; max resume failure tries"
+        "--metalink-base-uri:; metalink base URI"
+        "--metalink-enable-unique-protocol; enable unique protocol"
+        "--metalink-file:; metalink file"
+        "--metalink-language:; metalink language"
+        "--metalink-location:; metalink location"
+        "--metalink-os:; metalink OS"
+        "--metalink-preferred-protocol:; metalink preferred protocol"
+        "--metalink-version:; metalink version"
+        "--min-tls-version:; minimum TLS version"
+        "--multiple-interface:; multiple interfaces"
+        "--netrc-path:; netrc file path"
+        "--no-conf; disable config file"
+        "--no-file-allocation-limit:; no file alloc limit"
+        "--no-proxy:; domains to bypass proxy"
+        "--no-want-digest-header; disable Want-Digest header"
+        "--on-bt-download-complete:; command on BT download complete"
+        "--on-download-complete:; command on download complete"
+        "--on-download-error:; command on download error"
+        "--on-download-pause:; command on download pause"
+        "--on-download-start:; command on download start"
+        "--on-download-stop:; command on download stop"
+        "--optimize-concurrent-downloads; optimize concurrent downloads"
+        "--parameterized-uri; use parameterized URI"
+        "--pause; pause download after added"
+        "--pause-metadata; pause metadata download"
+        "--peer-agent:; peer agent string"
+        "--peer-id-prefix:; peer ID prefix"
+        "--piece-length:; piece length"
+        "--private-key:; private key file"
+        "--proxy-method:; proxy request method"
+        "--quiet; suppress output"
+        "--realtime-chunk-checksum; realtime chunk checksum"
+        "--referer:; HTTP referrer"
+        "--remove-control-file; remove control file"
+        "--retry-wait:; seconds between retries"
+        "--reuse-uri; reuse already used URIs"
+        "--rlimit-nofile:; rlimit for open files"
+        "--rpc-allow-origin-all; allow all origins for RPC"
+        "--rpc-certificate:; RPC certificate file"
+        "--rpc-listen-all; listen on all interfaces for RPC"
+        "--rpc-listen-port:; RPC listen port"
+        "--rpc-max-request-size:; max RPC request size"
+        "--rpc-private-key:; RPC private key file"
+        "--rpc-save-upload-metadata; save upload metadata via RPC"
+        "--rpc-secret:; RPC secret token"
+        "--rpc-secure; enable RPC encryption"
+        "--save-cookies:; save cookies to file"
+        "--save-not-found; save not-found downloads"
+        "--save-session:; save session to file"
+        "--save-session-interval:; session save interval"
+        "--seed-ratio:; seed ratio"
+        "--seed-time:; seed time in minutes"
+        "--select-file:; select file by index"
+        "--server-stat-if:; load server performance profile"
+        "--server-stat-of:; save server performance profile"
+        "--server-stat-timeout:; server stat timeout"
+        "--show-console-readout; show console readout"
+        "--socket-recv-buffer-size:; socket receive buffer size"
+        "--ssh-host-key-md:; SSH host public key checksum"
+        "--stderr; log to stderr"
+        "--stop:; stop after N seconds"
+        "--stop-with-process:; stop when PID exits"
+        "--stream-piece-selector:; piece selection algorithm"
+        "--summary-interval:; summary interval in seconds"
+        "--torrent-file:; torrent file"
+        "--truncate-console-readout; truncate console readout"
+        "--uri-selector:; URI selection algorithm"
+        "--version"
+        ) #<#
+
+        command -f completion//parseoptions -es
+        case $ARGOPT in
+        (-)
+                command -f completion//completeoptions
+                ;;
+        (--ftp-type)
+                complete -- binary ascii
+                ;;
+        (--proxy-method)
+                complete -- get tunnel
+                ;;
+        (--metalink-preferred-protocol)
+                complete -- http https ftp none
+                ;;
+        (--bt-min-crypto-level)
+                complete -- plain arc4
+                ;;
+        (--follow-metalink|--follow-torrent)
+                complete -- true mem false
+                ;;
+        (--file-allocation)
+                complete -- none prealloc trunc falloc
+                ;;
+        (--log-level|--console-log-level)
+                complete -- debug info notice warn error
+                ;;
+        (--uri-selector)
+                complete -- inorder feedback adaptive
+                ;;
+        (--event-poll)
+                complete -- epoll poll select
+                ;;
+        (--stream-piece-selector)
+                complete -- default inorder random geom
+                ;;
+        (--download-result)
+                complete -- default full hide
+                ;;
+        (--min-tls-version)
+                complete -- TLSv1.1 TLSv1.2 TLSv1.3
+                ;;
+        (d|--dir)
+                complete -P "$PREFIX" -S / -T -d
+                ;;
+        (--torrent-file)
+                complete -P "$PREFIX" -f
+                ;;
+        (--metalink-file)
+                complete -P "$PREFIX" -f
+                ;;
+        (i|--input-file|l|--log|o|--out|--conf-path|--ca-certificate|--certificate|--private-key|--load-cookies|--save-cookies|--save-session|--server-stat-if|--server-stat-of|--netrc-path|--rpc-certificate|--rpc-private-key|--dht-file-path|--dht-file-path6)
+                complete -P "$PREFIX" -f
+                ;;
+        ('')
+                complete -f
+                ;;
+        esac
+
+}
+
+
+# vim: set ft=sh ts=8 sts=8 sw=8 et:

--- a/share/completion/hdparm
+++ b/share/completion/hdparm
@@ -1,0 +1,43 @@
+# Completion script for the "hdparm" command.
+# NOTE: Partial flags included, might add more later
+
+function completion/hdparm {
+
+        typeset OPTIONS ARGOPT PREFIX
+        OPTIONS=( #>#
+        "I; display drive identification info directly from the drive"
+        "t; perform timings of device reads for benchmark"
+        "T; perform timings of cache reads for benchmark"
+        "B; get/set Advanced Power Management feature"
+        "S; set standby (spindown) timeout"
+        "C; check the current IDE power mode status"
+        "y; force drive to enter standby mode"
+        "Y; force drive to enter sleep mode"
+        "M; get/set Automatic Acoustic Management (AAM) setting"
+        "W; get/set the write-caching feature"
+        "J; get/set WD Green Drive idle3 timeout value"
+        "v; display some basic settings"
+        "--direct; use O_DIRECT flag for -t timing test"
+        "d; get/set the using_dma flag"
+        "i; display identification info from boot/configuration time"
+        "a; get/set sector count for filesystem read-ahead"
+        "A; get/set the read-lookahead feature"
+        "z; force a kernel re-read of the partition table"
+        "Q; get or set the command queue_depth"
+        "k; get/set the keep_settings_over_reset flag"
+        ) #<#
+
+        command -f completion//parseoptions
+        case $ARGOPT in
+        (-)
+                command -f completion//completeoptions
+                ;;
+        (*)
+                complete -P "$PREFIX" -f
+                ;;
+        esac
+
+}
+
+
+# vim: set ft=sh ts=8 sts=8 sw=8 et:

--- a/share/completion/mkinitcpio
+++ b/share/completion/mkinitcpio
@@ -1,0 +1,85 @@
+# Completion script for the "mkinitcpio" command.
+
+function completion/mkinitcpio {
+
+        typeset OPTIONS ARGOPT PREFIX
+        OPTIONS=( #>#
+        "A: --addhooks:; add hooks to the image"
+        "c: --config:; use specified config file"
+        "D: --hookdir:; set hook search directory"
+        "d: --generatedir:; set initramfs build directory"
+        "g: --generate:; generate a CPIO image"
+        "H: --hookhelp:; output help for a hook"
+        "h --help; show help"
+        "k: --kernel:; use specified kernel version"
+        "L --listhooks; list all available hooks"
+        "M --automods; display modules found via autodetection"
+        "n --nocolor; disable color output"
+        "P --allpresets; process all presets"
+        "p: --preset:; build image according to specified preset"
+        "R --remove; remove initramfs images for specified presets"
+        "r: --moduleroot:; specify root directory for modules"
+        "S: --skiphooks:; skip specified hooks"
+        "s --save; save the build directory"
+        "t: --builddir:; use specified temporary build directory"
+        "U: --uki:; generate a unified kernel image"
+        "V --version; display version information"
+        "v --verbose; verbose output"
+        "z: --compress:; override the compression method"
+        "--cmdline:; use kernel command line with UKI"
+        "--no-cmdline; omit kernel command line in UKI"
+        "--kernelimage:; include a kernel image for UKI"
+        "--osrelease:; include an os-release file for UKI"
+        "--splash:; include a splash bitmap for UKI"
+        "--uefistub:; specify UEFI stub image for UKI"
+        "--ukiconfig:; specify configuration file for ukify"
+        "--no-ukify; do not use ukify to build UKIs"
+        ) #<#
+
+        command -f completion//parseoptions -es
+        case $ARGOPT in
+        (-)
+                command -f completion//completeoptions
+                ;;
+        (A|--addhooks|H|--hookhelp|S|--skiphooks)
+                typeset f
+                for f in /usr/lib/initcpio/install/* /lib/initcpio/install/*; do
+                        [ -f "$f" ] && complete -- "${f##*/}"
+                done
+                ;;
+        (p|--preset)
+                typeset f
+                for f in /etc/mkinitcpio.d/*.preset; do
+                        [ -f "$f" ] || continue
+                        f="${f##*/}"
+                        complete -- "${f%.preset}"
+                done
+                ;;
+        (k|--kernel)
+                typeset f kver
+                for f in /boot/*; do
+                        if [ ! -L "$f" ] && [ -f "$f" ]; then
+                                kver=$(/usr/lib/initcpio/functions run_mkinitcpio_func kver "$f" 2>/dev/null) &&
+                                        complete -- "$f" &&
+                                        complete -- "$kver"
+                        fi
+                done
+                ;;
+        (D|--hookdir|d|--generatedir|r|--moduleroot|t|--builddir)
+                complete -P "$PREFIX" -S / -T -d
+                ;;
+        (c|--config|g|--generate|U|--uki|--cmdline|--kernelimage|--osrelease|--splash|--uefistub|--ukiconfig)
+                complete -P "$PREFIX" -f
+                ;;
+        (z|--compress)
+                return
+                ;;
+        (*)
+                command -f completion//completeoptions
+                ;;
+        esac
+
+}
+
+
+# vim: set ft=sh ts=8 sts=8 sw=8 et:

--- a/share/completion/mount
+++ b/share/completion/mount
@@ -1,0 +1,49 @@
+# Completion script for the "mount" command.
+# NOTE: only contains ubase's variant flags
+
+function completion/mount {
+
+        typeset OPTIONS ARGOPT PREFIX
+        OPTIONS=( #>#
+        "B; remount a subtree somewhere else"
+        "M; move a subtree to some other place"
+        "R; remount a subtree and all possible submounts somewhere else"
+        "a; mount all filesystems mentioned in /etc/fstab"
+        "n; mount without writing in /etc/mtab"
+        "o:; specify filesystem specific options"
+        "t:; set the filesystem type"
+        ) #<#
+
+        command -f completion//parseoptions
+        case $ARGOPT in
+        (-)
+                command -f completion//completeoptions
+                ;;
+        (o)
+                # fs specifc opts so no need for completion here
+                return
+                ;;
+        (t)
+                typeset fstype
+                if [ -r /proc/filesystems ]; then
+                        for fstype in $(awk '{print $NF}' /proc/filesystems); do
+                                complete -- "$fstype"
+                        done
+                fi
+                typeset kfs="/lib/modules/$(uname -r)/kernel/fs"
+                if [ -d "$kfs" ]; then
+                        for fstype in "$kfs"/*/; do
+                                fstype="${fstype%/}"
+                                complete -- "${fstype##*/}"
+                        done
+                fi
+                ;;
+        (*)
+                complete -P "$PREFIX" -T -f
+                ;;
+        esac
+
+}
+
+
+# vim: set ft=sh ts=8 sts=8 sw=8 et:

--- a/share/completion/sv
+++ b/share/completion/sv
@@ -1,0 +1,53 @@
+# Completion script for the runit "sv" command
+
+function completion/sv {
+        typeset commands="up down status once pause cont hup alarm interrupt 1 2 term kill exit start stop restart shutdown force-stop force-reload force-restart force-shutdown"
+
+        typeset OPTIONS ARGOPT PREFIX
+        OPTIONS=( #>#
+        "w:; specify the timeout in seconds"
+        "v; verbose"
+        ) #<#
+
+        command -f completion//parseoptions
+        case $ARGOPT in
+        (-)
+                command -f completion//completeoptions
+                ;;
+        (w)
+                return
+                ;;
+        (*)
+                typeset i=2 needcmd=true
+                while [ $i -le ${WORDS[#]} ]; do
+                        case ${WORDS[i]} in
+                        (-w)
+                                i=$((i + 2))
+                                ;;
+                        (-*)
+                                i=$((i + 1))
+                                ;;
+                        (*)
+                                needcmd=false
+                                break
+                                ;;
+                        esac
+                done
+
+                if $needcmd; then
+                        complete -- $commands
+                else
+                        typeset svdir="${SVDIR:-/var/service}"
+                        svdir="${svdir%/}"
+                        typeset svc
+                        for svc in "${svdir}/"*; do
+                                [ -d "$svc" ] && complete -- "${svc##*/}"
+                        done
+                fi
+                ;;
+        esac
+
+}
+
+
+# vim: set ft=sh ts=8 sts=8 sw=8 et:


### PR DESCRIPTION
Hello, this PR adds completion for several commands

- *mount*: is well known and used for fs mounting in various *nix environments, currently, I only flags used by [ubase](https://core.suckless.org/ubase/) variant.
- *sv*: is a small utility to manage service in the runit init system (used primarily by Void/Artix Linux).
- *aria2c*: is a versatile download utility, handles MANY sources and used under the hood by many other utilities such as yt-dlp.
- *mkinitcpio*: a utility that generates initramfs images, it packages/loads the kernel modules and tools (LUKS, LVM..) needed to mount the root filesystem and hand control to the system's init process.
- *7z*: the well known file archiver
- *hdparm*: a utility for viewing nd adjusting SATA/IDE hard drive hardware params, this includes: test read performance, set power management profiles (APM), and perform low-level tasks like Secure Erase (I only picked few flags that are used a lot).