### PR TITLE
Record logs in GitHub Actions when tests fail

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -20,8 +20,31 @@ jobs:
       run: ./configure
     - name: make distcheck
       run: make -j$(nproc) distcheck
+    - name: Display test summary on distcheck failure
+      if: failure()
+      run: |
+        if [ -f yash-*/tests/summary.log ]; then
+          echo "=== Test Summary ==="
+          cat yash-*/tests/summary.log
+        fi
     - name: make check as root
       run: sudo make -j$(nproc) check
+    - name: Display test summary on check failure
+      if: failure()
+      run: |
+        if [ -f tests/summary.log ]; then
+          echo "=== Test Summary ==="
+          cat tests/summary.log
+        fi
+    - name: Upload test logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-logs-ubuntu
+        path: |
+          tests/summary.log
+          yash-*/tests/summary.log
+        if-no-files-found: ignore
 
   check-on-macos:
     runs-on: macos-latest
@@ -34,6 +57,20 @@ jobs:
       run: ./configure CADDS="-I$(brew --prefix gettext)/include" LDADDS="-L$(brew --prefix gettext)/lib"
     - name: make check
       run: make -j$(sysctl -n hw.logicalcpu) check
+    - name: Display test summary on failure
+      if: failure()
+      run: |
+        if [ -f tests/summary.log ]; then
+          echo "=== Test Summary ==="
+          cat tests/summary.log
+        fi
+    - name: Upload test logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-logs-macos
+        path: tests/summary.log
+        if-no-files-found: ignore
 
   check-cross-compile:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The previous workflow only showed messages written to standard output/error, which is not ideal for debugging. This commit adds steps to display the test summary log on failure and upload the logs as artifacts for later inspection.