### PR TITLE
[docs] Fix prompt escape code for blinking font

### DIFF
--- a/doc/interact.txt
+++ b/doc/interact.txt
@@ -145,7 +145,7 @@ Make font color or background brighter
 +s+:: Make font standout
 +u+:: Make font underlined
 +v+:: Make font and background colors reversed
-+b+:: Make font blink
++n+:: Make font blink
 +i+:: Make font dim
 +o+:: Make font bold
 +x+:: Make font invisible


### PR DESCRIPTION
In the section for the escape codes for `PS1` and `PS2` in interact.txt - the escape code for blinking text is `\fn`, not `\fb`.