### PR TITLE
doc: Fix link to the translating information.

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -139,8 +139,8 @@ share/initialization/sample) ファイルを参考に自分用の `~/.yashrc`
  * [課題管理システム](https://github.com/magicant/yash/issues)
  * [掲示板](https://github.com/magicant/yash/discussions)
 
-翻訳に興味がおありの場合は
-[TRANSLATING.md](TRANSLATING.md) をご覧ください
+翻訳に興味がおありの場合は[CONTRIBUTING.md](CONTRIBUTING.md)の
+「Translating Messages Printed by Yash」の節をご覧ください
 
 
 ----------------------

--- a/README.md
+++ b/README.md
@@ -135,8 +135,9 @@ Comments, suggestions, and bug reports are welcome at:
  * [Issue tracking system](https://github.com/magicant/yash/issues)
  * [Discussion forum](https://github.com/magicant/yash/discussions)
 
-If you are interested in translation, please refer to
-[TRANSLATING.md](TRANSLATING.md).
+If you are interested in translation, please refer to the
+"Translating Messages Printed by Yash" section in
+[CONTRIBUTING.md](CONTRIBUTING.md).
 
 
 ----------------------


### PR DESCRIPTION
Hello, this is a minor fix of the link to the translation instruction.

The readme description shows it expects `TRANSLATING.md`, and there might have been there according to the past migration (#17).  However now the file doesn't exist.

See also web archive page before migration: <https://web.archive.org/web/20240222135447/https://osdn.net/projects/yash/wiki/HowToTranslate>