### PR TITLE
Add support for bracketed paste mode

### DIFF
--- a/doc/lineedit.txt
+++ b/doc/lineedit.txt
@@ -52,6 +52,10 @@ link:_set.html#so-lecompdebug[le-comp-debug]::
 When enabled, internal information is printed during
 <<completion,completion>>, which will help debugging completion scripts.
 
+link:_set.html#so-lebracketpaste[le-bracket-paste]::
+When enabled, instruct the terminal emulator to emit bracketed paste mode
+escape sequences. This allows detecting when the user is pasting to the shell.
+
 link:_set.html#so-leconvmeta[le-conv-meta]::
 When enabled, the 8th bit of each input byte is always treated as a meta-key
 flag, regardless of terminfo data.

--- a/lineedit/editing.c
+++ b/lineedit/editing.c
@@ -991,11 +991,11 @@ void cmd_setmode_emacs(wchar_t c __attribute__((unused)))
 }
 
 void cmd_bracketed_paste_start(wchar_t c __attribute__((unused))) {
-    le_bracketed_paste = true;
+    le_pasted_input = true;
 }
 
 void cmd_bracketed_paste_end(wchar_t c __attribute__((unused))) {
-    le_bracketed_paste = false;
+    le_pasted_input = false;
 }
 
 /* Changes the editing mode to the specified one. */

--- a/lineedit/editing.c
+++ b/lineedit/editing.c
@@ -990,6 +990,14 @@ void cmd_setmode_emacs(wchar_t c __attribute__((unused)))
     set_mode(LE_MODE_EMACS, false);
 }
 
+void cmd_bracketed_paste_start(wchar_t c __attribute__((unused))) {
+    le_bracketed_paste = true;
+}
+
+void cmd_bracketed_paste_end(wchar_t c __attribute__((unused))) {
+    le_bracketed_paste = false;
+}
+
 /* Changes the editing mode to the specified one. */
 void set_mode(le_mode_id_T newmode, bool overwrite)
 {

--- a/lineedit/editing.h
+++ b/lineedit/editing.h
@@ -69,6 +69,8 @@ extern le_command_func_T
     cmd_setmode_viinsert, /*C*/
     cmd_setmode_vicommand, /*C*/
     cmd_setmode_emacs, /*C*/
+    cmd_bracketed_paste_start, /*C*/
+    cmd_bracketed_paste_end, /*C*/
     cmd_expect_char, /*C*/
     cmd_abort_expect_char, /*C*/
     cmd_redraw_all, /*C*/

--- a/lineedit/key.h
+++ b/lineedit/key.h
@@ -216,6 +216,10 @@
 #define Key_escape    Key_c_lb
 #define Key_backslash L"\\\\"   // must end with '\\'
 
+/* See https://www.xfree86.org/4.7.0/ctlseqs.html#Bracketed%20Paste%20Mode */
+#define Key_br_start L"\\^[[200~"
+#define Key_br_stop  L"\\^[[201~"
+
 #define META_BIT    0x80
 #define ESCAPE_CHAR '\33'
 

--- a/lineedit/keymap.c
+++ b/lineedit/keymap.c
@@ -98,6 +98,8 @@ void le_keymap_init(void)
     Set(Key_c_n,       cmd_next_history_eol);
     Set(Key_up,        cmd_prev_history_eol);
     Set(Key_c_p,       cmd_prev_history_eol);
+    Set(Key_br_start,  cmd_bracketed_paste_start);
+    Set(Key_br_stop,   cmd_bracketed_paste_end);
     le_modes[LE_MODE_VI_INSERT].keymap = t;
 
     le_modes[LE_MODE_VI_COMMAND].default_command = cmd_alert;
@@ -300,6 +302,8 @@ void le_keymap_init(void)
     Set(Key_c_n,            cmd_next_history_eol);
     Set(Key_up,             cmd_prev_history_eol);
     Set(Key_c_p,            cmd_prev_history_eol);
+    Set(Key_br_start,       cmd_bracketed_paste_start);
+    Set(Key_br_stop,        cmd_bracketed_paste_end);
     le_modes[LE_MODE_EMACS].keymap = t;
 
     le_modes[LE_MODE_EMACS_SEARCH].default_command = cmd_srch_self_insert;

--- a/lineedit/lineedit.c
+++ b/lineedit/lineedit.c
@@ -159,6 +159,8 @@ static mbstate_t reader_state;
 static xwcsbuf_T reader_second_buffer;
 /* If true, next input will be inserted directly to the main buffer. */
 bool le_next_verbatim;
+/* If true, the user is currently pasting to the shell (bracketed paste mode). */
+bool le_bracketed_paste = false;
 
 /* Initializes the state of the reader. */
 void reader_init(bool trap)
@@ -332,8 +334,19 @@ process_keymap:
             case TG_EXACTMATCH:
                 assert(tg.matchlength > 0);
                 c = reader_second_buffer.contents[tg.matchlength - 1];
-                le_invoke_command(tg.value.cmdfunc, c);
-                wb_remove(&reader_second_buffer, 0, tg.matchlength);
+                /* In bracketed paste mode only allow cmd_bracketed_paste_end
+                 * to quit this mode, ignore all other commands/keybindings. */
+                if (le_bracketed_paste && tg.value.cmdfunc != cmd_bracketed_paste_end) {
+                    assert(reader_second_buffer.length > 1);
+                    for (size_t i = 1; i < reader_second_buffer.length; i++) {
+                        le_invoke_command(le_current_mode->default_command,
+                                reader_second_buffer.contents[i]);
+                    }
+                    wb_clear(&reader_second_buffer);
+                } else {
+                    le_invoke_command(tg.value.cmdfunc, c);
+                    wb_remove(&reader_second_buffer, 0, tg.matchlength);
+                }
                 break;
             case TG_PREFIXMATCH:
             case TG_AMBIGUOUS:

--- a/lineedit/lineedit.c
+++ b/lineedit/lineedit.c
@@ -71,7 +71,8 @@ inputresult_T le_readline(
     assert(le_state == LE_STATE_INACTIVE);
 
     if (!isatty(STDIN_FILENO) || !isatty(STDERR_FILENO)
-            || !le_setupterm(true) || !le_set_terminal())
+            || !le_set_bracketed(true) || !le_setupterm(true)
+            || !le_set_terminal())
         return INPUT_ERROR;
 
     le_state = LE_STATE_ACTIVE;
@@ -89,6 +90,7 @@ inputresult_T le_readline(
     reader_finalize();
     le_display_finalize();
     resultline = le_editing_finalize();
+    le_set_bracketed(false);
     le_restore_terminal();
     le_state = LE_STATE_INACTIVE;
 
@@ -115,6 +117,7 @@ void le_suspend_readline(void)
     if (le_state == LE_STATE_ACTIVE) {
         le_state = LE_STATE_SUSPENDED;
         le_display_clear(false);
+        le_set_bracketed(false);
         le_restore_terminal();
     }
 }
@@ -127,6 +130,7 @@ void le_resume_readline(void)
         le_state = LE_STATE_ACTIVE;
         le_setupterm(true);
         le_set_terminal();
+        le_set_bracketed(true);
         le_display_update(true);
         le_display_flush();
     }
@@ -160,7 +164,9 @@ static xwcsbuf_T reader_second_buffer;
 /* If true, next input will be inserted directly to the main buffer. */
 bool le_next_verbatim;
 /* If true, the user is currently pasting to the shell (bracketed paste mode). */
-bool le_bracketed_paste = false;
+bool le_pasted_input = false;
+/* TODO */
+bool le_conf_bracketed_paste = false;
 
 /* Initializes the state of the reader. */
 void reader_init(bool trap)
@@ -336,7 +342,7 @@ process_keymap:
                 c = reader_second_buffer.contents[tg.matchlength - 1];
                 /* In bracketed paste mode only allow cmd_bracketed_paste_end
                  * to quit this mode, ignore all other commands/keybindings. */
-                if (le_bracketed_paste && tg.value.cmdfunc != cmd_bracketed_paste_end) {
+                if (le_pasted_input && tg.value.cmdfunc != cmd_bracketed_paste_end) {
                     assert(reader_second_buffer.length > 1);
                     for (size_t i = 1; i < reader_second_buffer.length; i++) {
                         le_invoke_command(le_current_mode->default_command,

--- a/lineedit/lineedit.h
+++ b/lineedit/lineedit.h
@@ -51,8 +51,12 @@ extern void le_suspend_readline(void);
 extern void le_resume_readline(void);
 extern void le_display_size_changed(void);
 
+/* If this configuration option is enabled, the terminal emulator
+ * is instructed to send escape sequences to indicate pasting. */
+extern _Bool le_conf_bracketed_paste;
+
 extern _Bool le_next_verbatim;
-extern _Bool le_bracketed_paste;
+extern _Bool le_pasted_input; // requires `le_conf_bracketed_paste`
 
 extern void le_append_to_prebuffer(char *s)
     __attribute__((nonnull));

--- a/lineedit/lineedit.h
+++ b/lineedit/lineedit.h
@@ -52,6 +52,7 @@ extern void le_resume_readline(void);
 extern void le_display_size_changed(void);
 
 extern _Bool le_next_verbatim;
+extern _Bool le_bracketed_paste;
 
 extern void le_append_to_prebuffer(char *s)
     __attribute__((nonnull));

--- a/lineedit/terminfo.c
+++ b/lineedit/terminfo.c
@@ -56,6 +56,9 @@
 
 /********** TERMINFO **********/
 
+/* TODO: Obtain these sequences from terminfo. */
+#define BRACKETED_PASTE_INIT  "\033[?2004h"
+#define BRACKETED_PASTE_DENIT "\033[?2004l"
 
 /* terminfo capabilities */
 #define TI_am      "am"
@@ -958,6 +961,24 @@ _Bool le_allow_terminal_signal(_Bool allow)
     struct termios term = original_terminal_state;
     to_raw_mode(&term, allow);
     return xtcsetattr(STDIN_FILENO, TCSADRAIN, &term) == 0;
+}
+
+/* If `enable` is true, instructs the terminal emulator to start sending special
+ * escape sequences when pasting from the clipboard. Otherwise, the emulator is
+ * instructed to stop sending such sequences.
+ * If `le_conf_bracketed_paste` is not set, this function is a no-op.
+ * The return value indicates if the operation was succesfull. */
+_Bool le_set_bracketed(_Bool enable)
+{
+    if (!le_conf_bracketed_paste)
+        return true;
+
+    const char *mode = (enable) ?
+        BRACKETED_PASTE_INIT : BRACKETED_PASTE_DENIT;
+
+    if (!xprintf("%s", mode))
+        return false;
+    return fflush(stdout) == 0;
 }
 
 /* Modifies the specified termios structure into the "raw" mode values.

--- a/lineedit/terminfo.c
+++ b/lineedit/terminfo.c
@@ -56,15 +56,13 @@
 
 /********** TERMINFO **********/
 
-/* TODO: Obtain these sequences from terminfo. */
-#define BRACKETED_PASTE_INIT  "\033[?2004h"
-#define BRACKETED_PASTE_DENIT "\033[?2004l"
-
 /* terminfo capabilities */
 #define TI_am      "am"
 #define TI_bel     "bel"
 #define TI_blink   "blink"
 #define TI_bold    "bold"
+#define TI_brstart "BE"
+#define TI_brstop  "BD"
 #define TI_clear   "clear"
 #define TI_colors  "colors"
 #define TI_cols    "cols"
@@ -972,9 +970,11 @@ _Bool le_set_bracketed(_Bool enable)
 {
     if (!le_conf_bracketed_paste)
         return true;
+    const char *cap = (enable) ? TI_brstart : TI_brstop;
 
-    const char *mode = (enable) ?
-        BRACKETED_PASTE_INIT : BRACKETED_PASTE_DENIT;
+    char *mode = tigetstr(cap);
+    if (mode == (char *)-1)
+        return true; // assume bracketed paste is unsupported
 
     if (!xprintf("%s", mode))
         return false;

--- a/lineedit/terminfo.h
+++ b/lineedit/terminfo.h
@@ -70,6 +70,7 @@ extern _Bool le_set_terminal(void);
 extern _Bool le_save_terminal(void);
 extern _Bool le_restore_terminal(void);
 extern _Bool le_allow_terminal_signal(_Bool allow);
+extern _Bool le_set_bracketed(_Bool enable);
 
 
 #endif /* YASH_TERMINFO_H */

--- a/option.c
+++ b/option.c
@@ -37,6 +37,11 @@
 #include "util.h"
 #include "variable.h"
 
+/* Escape sequences which instruct the terminal emulator to inform us when
+ * input is pasted by the user to the terminal. These are required for the
+ * 'lebracketpaste' option. */
+#define BRACKETED_PASTE_INIT  "\033[?2004h"
+#define BRACKETED_PASTE_DENIT "\033[?2004l"
 
 /********** Option Definitions **********/
 
@@ -201,6 +206,8 @@ bool shopt_le_compdebug = false;
 /* If set, the right prompt will trim the extra space left at end for cursor
  * to sit if prompt is too large */
 bool shopt_le_trimright = false;
+/* If set, enable bracketed paste mode. */
+bool shopt_le_bracketed = false;
 #endif
 
 
@@ -241,6 +248,7 @@ static const struct option_T shell_options[] = {
 #if YASH_ENABLE_LINEEDIT
     { 0,    0,    L"lealwaysrp",     &shopt_le_alwaysrp,    true, },
     { 0,    0,    L"lecompdebug",    &shopt_le_compdebug,   true, },
+    { 0,    0,    L"lebracketpaste", &shopt_le_bracketed,   true, },
     { 0,    0,    L"leconvmeta",     &shopt_le_yesconvmeta, true, },
     { 0,    0,    L"lenoconvmeta",   &shopt_le_noconvmeta,  true, },
     { 0,    0,    L"lepredict",      &shopt_le_predict,     true, },
@@ -333,6 +341,7 @@ static int set_shell_option(const struct option_T *option, bool enable,
 #if YASH_ENABLE_LINEEDIT
 static void update_lineedit_option(void);
 static void update_le_convmeta_option(void);
+static void update_le_bracketed_option(void);
 #endif
 static int set_normal_option(const struct xgetopt_T *opt, const wchar_t *arg,
         struct shell_invocation_T *shell_invocation)
@@ -703,6 +712,8 @@ int set_shell_option(const struct option_T *option, bool enable,
         if (enable)
             shopt_le_yesconvmeta = false;
         update_le_convmeta_option();
+    } else if (option->optp == &shopt_le_bracketed) {
+        update_le_bracketed_option();
     }
 #endif
 
@@ -734,6 +745,14 @@ void update_le_convmeta_option(void)
         shopt_le_convmeta = SHOPT_NO;
     else
         shopt_le_convmeta = SHOPT_AUTO;
+}
+
+void update_le_bracketed_option(void)
+{
+    const char *mode = (shopt_le_bracketed) ?
+        BRACKETED_PASTE_INIT : BRACKETED_PASTE_DENIT;
+    xprintf("%s", mode);
+    fflush(stdout);
 }
 
 #endif

--- a/option.c
+++ b/option.c
@@ -36,12 +36,9 @@
 #include "strbuf.h"
 #include "util.h"
 #include "variable.h"
-
-/* Escape sequences which instruct the terminal emulator to inform us when
- * input is pasted by the user to the terminal. These are required for the
- * 'lebracketpaste' option. */
-#define BRACKETED_PASTE_INIT  "\033[?2004h"
-#define BRACKETED_PASTE_DENIT "\033[?2004l"
+#if YASH_ENABLE_LINEEDIT
+# include "lineedit/lineedit.h"
+#endif
 
 /********** Option Definitions **********/
 
@@ -749,10 +746,7 @@ void update_le_convmeta_option(void)
 
 void update_le_bracketed_option(void)
 {
-    const char *mode = (shopt_le_bracketed) ?
-        BRACKETED_PASTE_INIT : BRACKETED_PASTE_DENIT;
-    xprintf("%s", mode);
-    fflush(stdout);
+    le_conf_bracketed_paste = shopt_le_bracketed;
 }
 
 #endif

--- a/option.c
+++ b/option.c
@@ -244,8 +244,8 @@ static const struct option_T shell_options[] = {
     { L'i', 0,    L"interactive",    &is_interactive,       false, },
 #if YASH_ENABLE_LINEEDIT
     { 0,    0,    L"lealwaysrp",     &shopt_le_alwaysrp,    true, },
-    { 0,    0,    L"lecompdebug",    &shopt_le_compdebug,   true, },
     { 0,    0,    L"lebracketpaste", &shopt_le_bracketed,   true, },
+    { 0,    0,    L"lecompdebug",    &shopt_le_compdebug,   true, },
     { 0,    0,    L"leconvmeta",     &shopt_le_yesconvmeta, true, },
     { 0,    0,    L"lenoconvmeta",   &shopt_le_noconvmeta,  true, },
     { 0,    0,    L"lepredict",      &shopt_le_predict,     true, },


### PR DESCRIPTION
This patch adds support for bracketed paste mode to yash. Bracketed paste mode is a set of special escape sequences, which are employed by many terminal emulators to allow programs run inside of them to distinguish pasted text from typed-in text [\[0\]][0]. This is useful for preventing pasted text from accidentally executing commands in the application it was pasted to. Commonly this problem arises when copying text from a web browser to a shell since the user may have copied hidden text from the web page which may contain control characters [\[1\]][1].

Bracketed paste mode is supported by all mainstream terminal emulators. However, as implemented here, the feature must be explicitly enabled through a newly added option (`le-bracket-paste`). By setting this option, the terminal emulator is instructed to emit the start/stop sequence once the user starts pasting text. Disabling the option again configures the terminal emulator to no longer emit these start/stop sequences.

Currently, bracketed paste mode is only enabled in Vi insert mode and Emacs mode, we could consider enabling it in an additional modes in the future (e.g., the search mode).

For more information, refer to <https://invisible-island.net/xterm/xterm-paste64.html>

---

I just discovered yash a few days ago, so I haven't tested this extensively yet, but this was the first feature that I found to be lacking in yash. Hence, I have written this patch. Let me know if you are generally interested in this feature. Otherwise I will just apply it locally. Also looking for feedback on the implementation, ofc :)

[0]: https://www.xfree86.org/4.7.0/ctlseqs.html#Bracketed%20Paste%20Mode
[1]: https://thejh.net/misc/website-terminal-copy-paste